### PR TITLE
feat: wire frontend to real backend data (Phase 5b)

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -17,7 +17,7 @@ recap/
 │   ├── app.css                            # Tailwind base + Warm Ink dark theme
 │   ├── App.svelte                         # Hash routing, top nav bar, OAuth listeners
 │   ├── routes/
-│   │   ├── Dashboard.svelte               # Split-panel: FilterSidebar | MeetingList
+│   │   ├── Dashboard.svelte               # Split-panel: FilterSidebar | MeetingList + DetailPanel
 │   │   ├── MeetingDetail.svelte           # Full meeting view: player, notes, transcript, screenshots
 │   │   ├── GraphView.svelte               # d3-force graph + controls panel + sidebar
 │   │   └── Settings.svelte                # Provider connections, vault, recording, WhisperX config
@@ -29,9 +29,9 @@ recap/
 │       ├── stores/
 │       │   ├── credentials.ts             # Per-provider OAuth token state
 │       │   ├── settings.ts                # App settings with Tauri persistence
-│       │   ├── meetings.ts                # Meeting list, pagination, filters, derived filteredMeetings
+│       │   ├── meetings.ts                # Meeting list, pagination, filters, resetMeetings, graphDataVersion
 │       │   └── recorder.ts                # Recording state machine (idle → recording → processing)
-│       └── components/                    # 26 Svelte components (see Key Relationships)
+│       └── components/                    # 27 Svelte components (see Key Relationships)
 ├── recap/                                 # Python ML pipeline
 │   ├── pipeline.py                        # Stage-tracked orchestrator with status.json
 │   ├── transcribe.py / frames.py          # WhisperX transcription + video frame extraction
@@ -52,6 +52,7 @@ recap/
 │       ├── capture.rs / monitor.rs        # WASAPI audio + Graphics Capture screen recording
 │       ├── types.rs                       # RecorderState enum + shared types
 │       └── zoom.rs                        # Zoom meeting metadata extraction
+├── docs/plans/                            # Design specs + implementation plans per phase
 ├── prompts/meeting_analysis.md            # Claude prompt template for meeting analysis
 ├── scripts/build-sidecar.py               # Packages Python pipeline as Tauri sidecar
 ├── tests/                                 # Python tests (pytest): pipeline, transcribe, vault, etc.
@@ -63,15 +64,18 @@ recap/
 ## Key Relationships
 
 - `App.svelte` routes `#meeting/{id}` → MeetingDetail, `#graph` → GraphView, `#settings` → Settings
-- `Dashboard` renders FilterSidebar + MeetingList; clicking a row navigates to MeetingDetail route
-- `MeetingDetail` composes Header, Player, Notes, Transcript, ScreenshotGallery, PipelineStatusBadge
+- `Dashboard` renders FilterSidebar + MeetingList; clicking a row opens inline DetailPanel
+- `MeetingDetail` composes Header, Player, Notes, Transcript, ScreenshotGallery, PipelineDots
+- `PipelineDots` shows 6-stage dot indicators with expandable detail + retry; replaces PipelineStatusBadge
 - `MeetingTranscript` timestamp clicks seek `MeetingPlayer` (Vidstack) via shared time binding
 - `markdown.ts` renders `[[wikilinks]]` as `<a href="#filter/participant/{name}">` for filtering
-- `meetings.ts` store bridges IPC (list/search/filter) → derived `filteredMeetings` re-filters on change
-- `FilterSidebar` drives filter state in meetings store; filters include date, participants, pipeline status
+- `meetings.ts` store bridges IPC (list/search/filter) → derived `filteredMeetings`; `graphDataVersion` signals graph refresh
+- `FilterSidebar` drives filter state in meetings store; filters include company, participants, platform
+- `RecordingSettings` / `VaultSettings` call `resetMeetings()` on path changes (with value-change guards)
 - `dummy-data.ts` provides mock data when `VITE_DUMMY_DATA=true`; tree-shaken out of prod builds
 - `lib.rs` hides window on close (not quit), saves geometry; quit only via tray context menu
 - `oauth.rs` spawns localhost server for Google/Microsoft; `deep_link.rs` handles `recap://` callbacks
 - `recorder.rs` orchestrates monitor → capture → merge → zoom metadata → sidecar pipeline launch
 - `pipeline.py` writes `status.json` per stage; `--from`/`--only` flags enable retry from any stage
 - `GraphView` integrates GraphControls (d3 force sliders) + GraphSidebar (person/company drill-down)
+- `GraphView` watches `graphDataVersion` to refetch when settings paths change

--- a/docs/plans/2026-03-18-phase-5b-wire-real-data-design.md
+++ b/docs/plans/2026-03-18-phase-5b-wire-real-data-design.md
@@ -1,0 +1,158 @@
+# Phase 5b: Wire Frontend to Real Backend Data
+
+## Overview
+
+Connect existing Svelte frontend components to the Rust backend IPC commands that already exist. Replace all dummy data paths with real IPC calls, add error handling for missing/broken data, and surface pipeline progress on meeting cards.
+
+No new backend commands needed — all IPC endpoints are implemented.
+
+## Scope
+
+- Meetings store → real IPC (list, detail, search, filters, graph)
+- Asset protocol for recordings, vault notes, screenshots
+- Settings change reactivity
+- Error states for missing/misconfigured paths
+- Pipeline progress dot indicators (Approach C)
+- Dummy data preserved behind `VITE_DUMMY_DATA` env var
+
+## Meetings Store Wiring
+
+### list_meetings
+
+Replace `DUMMY_MEETINGS` with `invoke('list_meetings', { recordingsDir, vaultMeetingsDir, cursor, limit })`.
+
+Response: `MeetingListResponse { items: Vec<MeetingSummary>, next_cursor?: String }`
+
+- Initial load: no cursor, limit 25
+- "Load more" button appears when `next_cursor` is present
+- Appends to existing list (no full re-fetch)
+
+### get_meeting_detail
+
+Replace `getDummyDetail()` with `invoke('get_meeting_detail', { meetingId, recordingsDir, vaultMeetingsDir, framesDir })`.
+
+Response: `MeetingDetail { summary, note_content?, transcript?: Vec<Utterance>, screenshots: Vec<Screenshot> }`
+
+- DetailPanel and MeetingDetail both use this
+- Missing note → show "Generate Note" button
+- Missing transcript → show "Re-transcribe" button
+
+### search_meetings
+
+Replace client-side dummy filtering with `invoke('search_meetings', { query, recordingsDir, vaultMeetingsDir, limit })`.
+
+- Debounced input (300ms)
+- Replaces meeting list with search results
+- Clear search restores paginated list
+
+### get_filter_options
+
+Replace `DUMMY_FILTER_OPTIONS` with `invoke('get_filter_options', { recordingsDir })`.
+
+Response: `FilterOptions { companies, participants, platforms }`
+
+- Populates FilterSidebar checkboxes
+- Refreshed when recordings dir changes in Settings
+- Client-side filtering against loaded meeting list (filters don't trigger new IPC calls)
+
+### get_graph_data
+
+Replace `DUMMY_GRAPH_DATA` with `invoke('get_graph_data', { recordingsDir })`.
+
+Response: `GraphData { nodes: Vec<GraphNode>, edges: Vec<GraphEdge> }`
+
+- GraphView consumes directly
+- GraphSidebar filtered lists use client-side filtering of loaded meetings
+
+## Asset Protocol
+
+Already wired via `src/lib/assets.ts` → `convertFileSrc()` from `@tauri-apps/api/core`.
+
+Asset scope in `tauri.conf.json`: `["**/*"]` (permissive).
+
+Usage points:
+- **Recording playback:** `MeetingPlayer.svelte` passes `assetUrl(recording_path)` to Vidstack `<media-player>`
+- **Vault note rendering:** `DetailPanel.svelte` receives `note_content` as string from `get_meeting_detail` (backend reads the file), so no direct asset URL needed
+- **Frame screenshots:** `Screenshot.path` → `assetUrl(path)` for `<img>` tags in detail panel
+
+No changes needed to asset protocol configuration.
+
+## Settings Change Reactivity
+
+When user changes recordings dir or vault path in Settings:
+
+1. Settings store saves new values via `tauri-plugin-store`
+2. Meetings store exposes a `reset()` method that clears cached data and cursor
+3. Settings save calls `meetingsStore.reset()`
+4. Components that subscribe to the meetings store re-fetch on next render
+5. Filter options and graph data also invalidated
+
+Simple invalidation — no caching layer needed for Phase 5b.
+
+## Error Handling
+
+### Store-level errors
+
+Each store tracks an `error` state alongside its data:
+
+```typescript
+{ data: Meeting[] | null, loading: boolean, error: string | null }
+```
+
+### Error states by scenario
+
+| Scenario | Detection | UI |
+|---|---|---|
+| Recordings dir not configured | Settings store check | "Configure recordings directory in Settings" banner |
+| Vault path not configured | Settings store check | "Configure vault path in Settings" banner |
+| Recordings dir doesn't exist | IPC returns error | "Recordings directory not found" with Settings link |
+| IPC call fails (generic) | Catch in store | Inline error message with "Retry" button |
+| Individual meeting missing files | `has_note`, `has_transcript`, `has_video` flags on `MeetingSummary` | Per-card indicators + action buttons in detail |
+| Empty results | Items array empty | "No meetings found" empty state |
+
+## Pipeline Progress UI (Approach C)
+
+### Dot Indicators on Meeting Cards
+
+Each `MeetingSummary` includes `pipeline_status: PipelineStatus` with six stages: merge, frames, transcribe, diarize, analyze, export.
+
+Display as a row of 6 small dots on the meeting card:
+- **Completed:** accent color (`--accent`)
+- **Failed:** red (`--status-failed-text`)
+- **Pending:** muted (`--text-faint`)
+- **In progress:** accent with pulse animation
+
+### Expandable Inline Detail
+
+Click the dot row to expand a small section below the card showing:
+- Stage names with status icons
+- Timestamps for completed stages
+- Error messages for failed stages
+- Action buttons: "Retry from [stage]" for failed stages
+
+### Edge Case Buttons
+
+Surfaced in both the expanded dot detail and the DetailPanel:
+- **Missing vault note + has recording:** "Generate Note" → `retry_processing(recording_dir, from_stage: "analyze")`
+- **Missing/bad transcript + has recording:** "Re-transcribe" → `retry_processing(recording_dir, from_stage: "transcribe")`
+- **All stages failed:** "Reprocess" → `retry_processing(recording_dir, from_stage: "merge")`
+
+## Dummy Data Preservation
+
+- `VITE_DUMMY_DATA=true` in `.env.development` continues to work
+- Each store checks `USE_DUMMY_DATA` before making IPC calls
+- Pattern: `if (USE_DUMMY_DATA) return dummyData; else return invoke(...)`
+- Real data is the default when env var is absent or false
+
+## Files Modified
+
+- `src/lib/stores/meetings.ts` — real IPC calls, pagination, error states
+- `src/routes/Dashboard.svelte` — error state rendering, settings check
+- `src/lib/components/DetailPanel.svelte` — real detail loading, edge case buttons
+- `src/lib/components/FilterSidebar.svelte` — real filter options
+- `src/routes/GraphView.svelte` — real graph data
+- `src/lib/components/GraphSidebar.svelte` — filtered from real data
+- `src/lib/components/MeetingCard.svelte` — pipeline dot indicators (new)
+- `src/lib/components/PipelineStatus.svelte` — expandable stage detail (new)
+- `src/routes/Settings.svelte` — store reset on path changes
+- `src/lib/tauri.ts` — verify type interfaces match actual backend responses

--- a/docs/plans/2026-03-18-phase-5b-wire-real-data.md
+++ b/docs/plans/2026-03-18-phase-5b-wire-real-data.md
@@ -1,0 +1,725 @@
+# Phase 5b: Wire Frontend to Real Backend Data — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace all dummy data paths with real Tauri IPC calls, add pipeline dot indicators to meeting cards, and wire settings changes to store invalidation.
+
+**Architecture:** The stores (`meetings.ts`) and IPC wrappers (`tauri.ts`) already call real backend commands when `USE_DUMMY_DATA` is false. Main work is: pipeline dot indicators on meeting cards, search debounce, settings→store reactivity, and actionable error states. Minimal new files — mostly modifications to existing components.
+
+**Tech Stack:** Svelte 5, Tauri v2 IPC (`@tauri-apps/api/core`), `tauri-plugin-store`, d3-force (existing)
+
+---
+
+### Task 1: Add reset function to meetings store
+
+The settings store needs to trigger a meetings reload when paths change. Add a `resetMeetings()` export and a graph data store.
+
+**Files:**
+- Modify: `src/lib/stores/meetings.ts`
+
+**Step 1: Add reset and graph store exports**
+
+Add these functions after the existing `destroyMeetingsListener` function at line 261:
+
+```typescript
+/** Reset meetings state and reload. Called when settings paths change. */
+export async function resetMeetings(): Promise<void> {
+  meetings.set({ ...initial });
+  activeFilters.set({ ...initialFilters });
+  filterOptions.set({ companies: [], participants: [], platforms: [] });
+  await loadMeetings();
+  await loadFilterOptions();
+}
+```
+
+**Step 2: Verify the store compiles**
+
+Run: `cd "C:\Users\tim\OneDrive\Documents\Projects\recap" && npx tsc --noEmit`
+Expected: No new type errors
+
+**Step 3: Commit**
+
+```bash
+git add src/lib/stores/meetings.ts
+git commit -m "feat(stores): add resetMeetings for settings change reactivity"
+```
+
+---
+
+### Task 2: Wire settings changes to store invalidation
+
+When the user changes `recordingsFolder` or `vaultPath` in Settings, the meetings list and filters should refresh.
+
+**Files:**
+- Modify: `src/routes/Settings.svelte`
+
+**Step 1: Read Settings.svelte to find the save handlers**
+
+Read `src/routes/Settings.svelte` and locate where `saveSetting` or `saveAllSettings` is called for `recordingsFolder` and `vaultPath`.
+
+**Step 2: Import resetMeetings and call it after path changes**
+
+At the top of Settings.svelte `<script>`, add:
+
+```typescript
+import { resetMeetings } from "../lib/stores/meetings";
+```
+
+In each save handler for `recordingsFolder` and `vaultPath`, add a call to `resetMeetings()` after the `saveSetting()` call:
+
+```typescript
+await saveSetting("recordingsFolder", value);
+await resetMeetings();
+```
+
+```typescript
+await saveSetting("vaultPath", value);
+await resetMeetings();
+```
+
+**Step 3: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No new type errors
+
+**Step 4: Commit**
+
+```bash
+git add src/routes/Settings.svelte
+git commit -m "feat(settings): reload meetings when recordings/vault paths change"
+```
+
+---
+
+### Task 3: Add search debounce to Dashboard
+
+Currently search fires on every keystroke. Add 300ms debounce.
+
+**Files:**
+- Modify: `src/routes/Dashboard.svelte`
+
+**Step 1: Add debounce to the search handler**
+
+Replace the `handleSearch` function (line 63-69) with:
+
+```typescript
+let searchTimer: ReturnType<typeof setTimeout> | null = null;
+
+function handleSearch(query: string) {
+  if (searchTimer) clearTimeout(searchTimer);
+  if (!query.trim()) {
+    clearSearch();
+    return;
+  }
+  searchTimer = setTimeout(() => {
+    search(query.trim());
+  }, 300);
+}
+```
+
+Add cleanup in `onDestroy`:
+
+```typescript
+onDestroy(() => {
+  destroyRecorderListener();
+  destroyMeetingsListener();
+  if (searchTimer) clearTimeout(searchTimer);
+});
+```
+
+**Step 2: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+**Step 3: Commit**
+
+```bash
+git add src/routes/Dashboard.svelte
+git commit -m "feat(dashboard): add 300ms debounce to meeting search"
+```
+
+---
+
+### Task 4: Add pipeline dot indicators to MeetingRow
+
+Replace the single `PipelineStatusBadge` on meeting cards with a row of 6 colored dots showing each pipeline stage.
+
+**Files:**
+- Create: `src/lib/components/PipelineDots.svelte`
+- Modify: `src/lib/components/MeetingRow.svelte`
+
+**Step 1: Create PipelineDots component**
+
+```svelte
+<script lang="ts">
+  import type { PipelineStatus } from "../tauri";
+
+  interface Props {
+    status: PipelineStatus;
+  }
+
+  let { status }: Props = $props();
+
+  const stages = ["merge", "frames", "transcribe", "diarize", "analyze", "export"] as const;
+
+  function dotColor(stage: typeof stages[number]): string {
+    const s = status[stage];
+    if (s.error) return "#D06850";      // failed — red
+    if (s.completed) return "#A8A078";   // done — accent gold
+    return "#464440";                     // pending — muted
+  }
+
+  function dotTitle(stage: typeof stages[number]): string {
+    const s = status[stage];
+    if (s.error) return `${stage}: ${s.error}`;
+    if (s.completed) return `${stage}: done`;
+    return `${stage}: pending`;
+  }
+</script>
+
+<div
+  class="flex items-center gap-1"
+  title="Pipeline status"
+  role="img"
+  aria-label="Pipeline progress: {stages.map(s => `${s} ${status[s].completed ? 'complete' : status[s].error ? 'failed' : 'pending'}`).join(', ')}"
+>
+  {#each stages as stage}
+    <span
+      style="
+        display: inline-block;
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: {dotColor(stage)};
+        flex-shrink: 0;
+      "
+      title={dotTitle(stage)}
+    ></span>
+  {/each}
+</div>
+```
+
+**Step 2: Replace PipelineStatusBadge with PipelineDots in MeetingRow**
+
+In `src/lib/components/MeetingRow.svelte`, change the import (line 3):
+
+```typescript
+// Old:
+import PipelineStatusBadge from "./PipelineStatusBadge.svelte";
+// New:
+import PipelineDots from "./PipelineDots.svelte";
+```
+
+Replace the component usage (line 103):
+
+```svelte
+<!-- Old: -->
+<PipelineStatusBadge status={meeting.pipeline_status} />
+<!-- New: -->
+<PipelineDots status={meeting.pipeline_status} />
+```
+
+**Step 3: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+**Step 4: Commit**
+
+```bash
+git add src/lib/components/PipelineDots.svelte src/lib/components/MeetingRow.svelte
+git commit -m "feat(ui): replace pipeline badge with dot indicators on meeting cards"
+```
+
+---
+
+### Task 5: Add expandable pipeline detail to PipelineDots
+
+Make the dots clickable to expand an inline detail panel showing stage names, timestamps, errors, and retry buttons.
+
+**Files:**
+- Modify: `src/lib/components/PipelineDots.svelte`
+
+**Step 1: Add expandable detail**
+
+Rewrite `PipelineDots.svelte` to add click-to-expand behavior:
+
+```svelte
+<script lang="ts">
+  import type { PipelineStatus } from "../tauri";
+  import { retryProcessing } from "../tauri";
+
+  interface Props {
+    status: PipelineStatus;
+    recordingPath?: string | null;
+  }
+
+  let { status, recordingPath = null }: Props = $props();
+
+  let expanded = $state(false);
+  let retrying = $state<string | null>(null);
+
+  const stages = ["merge", "frames", "transcribe", "diarize", "analyze", "export"] as const;
+
+  function dotColor(stage: typeof stages[number]): string {
+    const s = status[stage];
+    if (s.error) return "#D06850";
+    if (s.completed) return "#A8A078";
+    return "#464440";
+  }
+
+  function dotTitle(stage: typeof stages[number]): string {
+    const s = status[stage];
+    if (s.error) return `${stage}: ${s.error}`;
+    if (s.completed) return `${stage}: done`;
+    return `${stage}: pending`;
+  }
+
+  function statusIcon(stage: typeof stages[number]): string {
+    const s = status[stage];
+    if (s.error) return "\u2717";   // cross mark
+    if (s.completed) return "\u2713"; // check mark
+    return "\u2022";                  // bullet
+  }
+
+  function formatTimestamp(ts: string | null): string {
+    if (!ts) return "";
+    try {
+      return new Date(ts).toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+    } catch {
+      return "";
+    }
+  }
+
+  async function retryFrom(stage: string) {
+    if (!recordingPath || retrying) return;
+    retrying = stage;
+    try {
+      await retryProcessing(recordingPath, stage);
+    } catch (e) {
+      console.error("Retry failed:", e);
+    } finally {
+      retrying = null;
+    }
+  }
+
+  function handleDotsClick(e: MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    expanded = !expanded;
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      expanded = !expanded;
+    }
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div style="display: flex; flex-direction: column; align-items: flex-end;">
+  <button
+    class="dots-row"
+    onclick={handleDotsClick}
+    onkeydown={handleKeydown}
+    title="Click to {expanded ? 'collapse' : 'expand'} pipeline details"
+    aria-expanded={expanded}
+    aria-label="Pipeline progress: {stages.map(s => `${s} ${status[s].completed ? 'complete' : status[s].error ? 'failed' : 'pending'}`).join(', ')}"
+  >
+    {#each stages as stage}
+      <span
+        class="dot"
+        style="background: {dotColor(stage)};"
+        title={dotTitle(stage)}
+      ></span>
+    {/each}
+  </button>
+
+  {#if expanded}
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <div
+      class="pipeline-detail"
+      onclick={(e) => e.stopPropagation()}
+    >
+      {#each stages as stage}
+        {@const s = status[stage]}
+        <div class="stage-row">
+          <span class="stage-icon" style="color: {dotColor(stage)};">{statusIcon(stage)}</span>
+          <span class="stage-name">{stage}</span>
+          {#if s.completed && s.timestamp}
+            <span class="stage-time">{formatTimestamp(s.timestamp)}</span>
+          {/if}
+          {#if s.error}
+            <span class="stage-error">{s.error}</span>
+            {#if recordingPath}
+              <button
+                class="retry-btn"
+                onclick={() => retryFrom(stage)}
+                disabled={retrying !== null}
+              >
+                {retrying === stage ? "..." : "Retry"}
+              </button>
+            {/if}
+          {/if}
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .dots-row {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    padding: 4px 6px;
+    border-radius: 4px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    transition: background 120ms ease;
+  }
+
+  .dots-row:hover {
+    background: rgba(168, 160, 120, 0.08);
+  }
+
+  .dot {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .pipeline-detail {
+    margin-top: 6px;
+    padding: 8px 10px;
+    border-radius: 6px;
+    background: #1A1A18;
+    font-family: 'DM Sans', sans-serif;
+    font-size: 12px;
+    min-width: 200px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .stage-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .stage-icon {
+    font-size: 11px;
+    width: 14px;
+    text-align: center;
+    flex-shrink: 0;
+  }
+
+  .stage-name {
+    color: #B0ADA5;
+    font-weight: 500;
+    min-width: 70px;
+  }
+
+  .stage-time {
+    color: #585650;
+    font-size: 11px;
+  }
+
+  .stage-error {
+    color: #D06850;
+    font-size: 11px;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .retry-btn {
+    padding: 1px 8px;
+    border-radius: 4px;
+    border: none;
+    background: rgba(200, 80, 60, 0.15);
+    color: #D06850;
+    font-family: 'DM Sans', sans-serif;
+    font-size: 11px;
+    font-weight: 600;
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+
+  .retry-btn:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+</style>
+```
+
+**Step 2: Pass recordingPath to PipelineDots in MeetingRow**
+
+In `MeetingRow.svelte`, update the PipelineDots usage:
+
+```svelte
+<PipelineDots status={meeting.pipeline_status} recordingPath={meeting.recording_path} />
+```
+
+**Step 3: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+**Step 4: Commit**
+
+```bash
+git add src/lib/components/PipelineDots.svelte src/lib/components/MeetingRow.svelte
+git commit -m "feat(ui): add expandable pipeline stage detail to dot indicators"
+```
+
+---
+
+### Task 6: Improve error states with actionable messages
+
+Add clear error messages when settings aren't configured, with links to Settings.
+
+**Files:**
+- Modify: `src/routes/Dashboard.svelte`
+- Modify: `src/routes/GraphView.svelte`
+
+**Step 1: Add configure-settings banner to Dashboard**
+
+In `Dashboard.svelte`, after the existing error block (line 171-183), add a no-recordings-dir banner. Read the settings store to detect unconfigured state.
+
+Add import at top:
+```typescript
+import { settings } from "../lib/stores/settings";
+```
+
+After the error div (line 183), add:
+
+```svelte
+{#if !$settings.recordingsFolder}
+  <div
+    class="mt-4 p-4 rounded-lg"
+    style="
+      background: rgba(180,165,130,0.08);
+      font-family: 'DM Sans', sans-serif;
+      font-size: 14.5px;
+      color: #B4A882;
+      text-align: center;
+    "
+  >
+    <p style="margin: 0 0 8px 0;">No recordings folder configured</p>
+    <a
+      href="#settings"
+      style="
+        color: #A8A078;
+        text-decoration: underline;
+        font-weight: 600;
+      "
+    >
+      Configure in Settings
+    </a>
+  </div>
+{/if}
+```
+
+**Step 2: Add same pattern to GraphView**
+
+In `GraphView.svelte`, the error state already shows "No recordings folder configured" (line 431). Make it a clickable link to Settings:
+
+Replace lines 511-512:
+```svelte
+<!-- Old: -->
+<div class="graph-message graph-error">{error}</div>
+<!-- New: -->
+<div class="graph-message graph-error">
+  {error}
+  {#if error?.includes("No recordings folder")}
+    <br />
+    <a href="#settings" style="color: #A8A078; text-decoration: underline; font-weight: 600; margin-top: 8px; display: inline-block;">
+      Configure in Settings
+    </a>
+  {/if}
+</div>
+```
+
+**Step 3: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+**Step 4: Commit**
+
+```bash
+git add src/routes/Dashboard.svelte src/routes/GraphView.svelte
+git commit -m "feat(ui): add actionable error states with Settings links"
+```
+
+---
+
+### Task 7: Verify real IPC path end-to-end
+
+Confirm that with `VITE_DUMMY_DATA` unset (or set to false), the app correctly calls IPC and handles empty/error responses gracefully.
+
+**Files:**
+- Modify: `.env.development` (temporarily)
+
+**Step 1: Disable dummy data**
+
+In `.env.development`, comment out or set to false:
+
+```
+# VITE_DUMMY_DATA=true
+VITE_DUMMY_DATA=false
+```
+
+**Step 2: Start the dev server**
+
+Run: `cd "C:\Users\tim\OneDrive\Documents\Projects\recap" && npm run tauri dev`
+
+**Step 3: Verify behaviors**
+
+Check each view manually:
+- **Dashboard:** Should show "No recordings folder configured" banner (or empty list if folder is set but empty)
+- **Graph:** Should show appropriate error/empty message
+- **Settings:** Should load and save without errors
+- **Search:** Should debounce (type quickly, only one IPC call)
+- **Filter sidebar:** Should show empty filter options (no recordings to scan)
+
+**Step 4: Restore dummy data and commit**
+
+Set `.env.development` back:
+```
+VITE_DUMMY_DATA=true
+```
+
+No code changes to commit from this task — it's a verification step.
+
+---
+
+### Task 8: Wire PipelineDots into DetailPanel
+
+The DetailPanel already shows `PipelineStatusBadge` — replace it with `PipelineDots` for consistency.
+
+**Files:**
+- Modify: `src/lib/components/DetailPanel.svelte`
+
+**Step 1: Replace badge with dots in DetailPanel**
+
+Change the import (line 12):
+```typescript
+// Old:
+import PipelineStatusBadge from "./PipelineStatusBadge.svelte";
+// New:
+import PipelineDots from "./PipelineDots.svelte";
+```
+
+Replace the usage (line 109):
+```svelte
+<!-- Old: -->
+<PipelineStatusBadge status={detail.summary.pipeline_status} />
+<!-- New: -->
+<PipelineDots status={detail.summary.pipeline_status} recordingPath={detail.summary.recording_path} />
+```
+
+**Step 2: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+**Step 3: Commit**
+
+```bash
+git add src/lib/components/DetailPanel.svelte
+git commit -m "feat(detail): use pipeline dots in detail panel for consistency"
+```
+
+---
+
+### Task 9: Verify type alignment between frontend and backend
+
+Confirm that all TypeScript interfaces in `tauri.ts` match the actual Rust struct serialization.
+
+**Files:**
+- Read: `src/lib/tauri.ts`
+- Read: `src-tauri/src/meetings.rs`
+- Read: `src-tauri/src/recorder/types.rs`
+
+**Step 1: Compare TypeScript types to Rust structs**
+
+Read `src-tauri/src/meetings.rs` and `src-tauri/src/recorder/types.rs`. For each Rust struct with `#[derive(Serialize)]`, verify the TypeScript interface in `tauri.ts` has matching field names (Rust uses snake_case, Tauri serializes to camelCase by default unless `#[serde(rename_all = "snake_case")]` is used — check which convention is in use).
+
+**Step 2: Fix any mismatches**
+
+If any fields are missing or named differently, update `tauri.ts` to match. Pay special attention to:
+- `PipelineStatus` and `PipelineStageStatus` (field names)
+- `MeetingSummary` (all optional fields)
+- `RecorderState` (enum variant serialization)
+
+**Step 3: Commit any fixes**
+
+```bash
+git add src/lib/tauri.ts
+git commit -m "fix(types): align TypeScript interfaces with Rust struct serialization"
+```
+
+If no fixes needed, skip this commit.
+
+---
+
+### Task 10: Final integration test and cleanup
+
+Run the full app with dummy data enabled and verify all changes work together.
+
+**Files:**
+- No modifications expected
+
+**Step 1: Run the dev server**
+
+```bash
+cd "C:\Users\tim\OneDrive\Documents\Projects\recap" && npm run tauri dev
+```
+
+**Step 2: Test each feature**
+
+- [ ] Meeting list loads with dummy data
+- [ ] Pipeline dots appear on each meeting card (6 dots, colored by stage)
+- [ ] Clicking dots expands stage detail inline
+- [ ] Retry buttons appear for failed stages in expanded detail
+- [ ] Search debounces (type quickly, results don't flicker)
+- [ ] Detail panel shows pipeline dots instead of badge
+- [ ] Graph view loads
+- [ ] Filter sidebar works
+- [ ] Settings page loads, changing recordings folder triggers meetings reload
+
+**Step 3: Run type check**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: No errors
+
+**Step 4: Commit if any final tweaks needed**
+
+---
+
+### Summary
+
+| Task | Description | New Files | Modified Files |
+|------|-------------|-----------|----------------|
+| 1 | Reset function in meetings store | — | `meetings.ts` |
+| 2 | Settings→store reactivity | — | `Settings.svelte` |
+| 3 | Search debounce | — | `Dashboard.svelte` |
+| 4 | Pipeline dots component | `PipelineDots.svelte` | `MeetingRow.svelte` |
+| 5 | Expandable dot detail | — | `PipelineDots.svelte`, `MeetingRow.svelte` |
+| 6 | Actionable error states | — | `Dashboard.svelte`, `GraphView.svelte` |
+| 7 | End-to-end IPC verification | — | `.env.development` (temp) |
+| 8 | Detail panel dots | — | `DetailPanel.svelte` |
+| 9 | Type alignment check | — | `tauri.ts` (if needed) |
+| 10 | Integration test | — | — |

--- a/docs/plans/2026-03-18-phase-5c-backend-additions-design.md
+++ b/docs/plans/2026-03-18-phase-5c-backend-additions-design.md
@@ -1,0 +1,142 @@
+# Phase 5c: Backend Additions — Calendar, Speaker Correction, Notifications
+
+## Status: Design Draft — Needs Further Brainstorming
+
+This document captures the current design direction. Sections marked 🔶 require additional brainstorming before implementation planning.
+
+## Overview
+
+Add new Rust backend capabilities and their frontend integration: Zoho Calendar polling with local cache, speaker diarization correction with hybrid pipeline pausing, and pre-meeting briefing notifications.
+
+## Section 1: Calendar Integration
+
+### Backend (Rust)
+
+New Tauri commands:
+- `fetch_calendar_events(date_range)` — calls Zoho Calendar API using stored OAuth tokens, returns events
+- `get_upcoming_meetings(hours_ahead)` — returns cached events within the time window
+- `sync_calendar()` — manual refresh trigger
+
+Caching:
+- Store last-known calendar data as JSON in Tauri app data directory
+- Automatic refresh twice daily (configurable)
+- Stale indicator when cache is older than refresh interval and API is unreachable
+
+Calendar → recording matching:
+- Compare calendar event time windows against recording timestamps
+- Match on overlap (event start/end vs recording start time ± duration)
+- Store matches in cache for fast lookup
+
+Auto-record:
+- Per-event or per-series flag stored in calendar cache
+- When a matching calendar event is approaching and auto-record is on, prepare recorder
+
+### Frontend (Svelte)
+
+- "Calendar" tab or sub-section in top nav
+- Upcoming meetings list: participant names, time, company, auto-record toggle
+- Past calendar events linked to recordings when matched
+- Empty state: "Connect Zoho Calendar in Settings"
+- Last-synced timestamp shown in calendar view
+
+### 🔶 Needs Brainstorming
+
+- **Calendar invitation content:** How to access the email body/description from calendar invitations for pre-meeting briefings when no prior meetings exist. Does Zoho Calendar API return event descriptions or notes? Or do we need Zoho Mail API integration? This affects the briefing feature in Section 3.
+- **Cache format:** Exact JSON schema for cached events. What fields do we need from Zoho's API response?
+- **Invalidation beyond twice-daily:** Should we also refresh on app focus? On manual pull-to-refresh? When the user opens the Calendar tab?
+- **OAuth scope:** Current Zoho OAuth may need additional scopes for calendar read access. Verify against Zoho Calendar API docs.
+
+## Section 2: Speaker Correction UI
+
+### Hybrid Pipeline Pause
+
+The pipeline runs fully if all speakers are identified by diarization. It only pauses if unidentified speakers remain ("Speaker 1", "Speaker 2", etc.).
+
+**When all speakers identified:**
+1. Pipeline runs to completion (merge → frames → transcribe → diarize → analyze → export)
+2. Vault note generated immediately
+3. Speaker correction still accessible from detail panel — corrections trigger re-analysis and note regeneration
+
+**When unidentified speakers present:**
+1. Pipeline runs through diarization, then pauses
+2. Meeting card shows "Needs Speaker Review" indicator
+3. User corrects speaker labels
+4. Pipeline resumes from analyze stage with corrected labels
+5. Vault note generated with correct attributions
+
+### Backend (Rust)
+
+New command: `update_speaker_labels(recording_dir, corrections: Map<String, String>)`
+- Writes corrections to `speaker_labels.json` alongside the recording
+- Triggers `retry_processing(recording_dir, from_stage: "analyze")`
+
+### Pipeline (Python sidecar)
+
+- After diarization, check if any speakers are unidentified (generic "Speaker N" labels)
+- If all identified: continue to analyze
+- If unidentified present: set `PipelineStatus.diarize.completed = true`, leave `analyze` as pending with a status indicating "awaiting speaker review", then exit
+- On resume: read `speaker_labels.json`, apply corrections to transcript, proceed with analysis
+
+### Frontend (Svelte)
+
+- "Needs Speaker Review" badge on meeting cards with unidentified speakers
+- Speaker review interface: transcript preview with speaker labels, correction controls
+- For completed meetings: speaker correction accessible from detail panel transcript tab
+- After correction: visual feedback showing pipeline resuming
+
+### 🔶 Needs Brainstorming
+
+- **Speaker review UX:** Inline in detail panel? Modal? Dedicated view? Consider that this might be a quick 2-speaker fix or a complex 8-person meeting.
+- **Speaker dropdown population:** From calendar event participants? Manual entry? Both? Address book / contact list?
+- **Pipeline "paused" status model:** New enum value in `PipelineStatus`? Special status string on the analyze stage? How does the frontend distinguish "waiting for review" from "failed"?
+- **Speaker identification logic:** How does the sidecar determine if a speaker is "identified" vs generic? Name matching against participant list? Confidence threshold from Pyannote?
+
+## Section 3: Meeting Notifications with Pre-Meeting Briefing
+
+### Backend (Rust)
+
+- Periodic check against cached calendar data (on app focus + configurable timer)
+- Configurable lead time: 5, 10, or 15 minutes before meeting
+- New command: `generate_briefing(company, participants)` — queries past meetings with same company/participants, assembles summary
+
+Briefing data assembly:
+- Query recordings dir for past meetings matching company or participant overlap
+- Read vault notes for matched meetings
+- Compile into briefing format
+
+### Frontend (Svelte)
+
+- System tray notification via `tauri-plugin-notification` (already configured)
+- Notification includes: meeting title, time, participant names, "View Briefing" action
+- "View Briefing" link opens briefing panel in the app
+- Briefing also accessible from Calendar tab → click upcoming meeting → "Meeting Prep" section
+- No previous meetings → briefing based on calendar invitation content
+- Settings: notification toggle, lead time selector (5/10/15 min)
+
+### Briefing Content
+
+When previous meetings exist:
+- Summary of key discussion points from recent meetings with the same company/participants
+- Open action items attributed to meeting participants
+- Relationship context (how long you've been meeting, frequency)
+
+When no previous meetings exist:
+- Note that this is the first meeting with these participants
+- Any context from calendar invitation description/notes
+
+### 🔶 Needs Brainstorming
+
+- **Summarization engine:** Where does the briefing summary happen? Options:
+  - LLM call via Python sidecar (`--briefing` mode) — best quality, requires API call
+  - Rust reads vault notes directly, extracts summary sections — no API cost, simpler, but less intelligent
+  - Hybrid: Rust extracts, Python/LLM summarizes only when multiple meetings need condensing
+- **Briefing format:** Bullet points? Structured sections? Configurable depth?
+- **Lookback window:** How far back for "previous meetings"? All time? Last 6 months? Last N meetings?
+- **Calendar invitation content:** Depends on Section 1 brainstorming — need to resolve Zoho Calendar API capabilities first
+- **Notification action:** Can Tauri notifications include clickable action buttons that open a specific view in the app? Or just a generic "click to open" that we route internally?
+
+## Dependencies
+
+- Section 1 (Calendar) blocks Section 3 (Notifications) — briefings need calendar data and invitation content
+- Section 2 (Speaker Correction) is independent and can be built in parallel with Section 1
+- All sections depend on Phase 5b being complete (real data wiring established)

--- a/docs/plans/future-phases.md
+++ b/docs/plans/future-phases.md
@@ -1,0 +1,39 @@
+# Future Phases — Deferred Features
+
+Features explicitly deferred from current phases. Each should be scoped into its own phase when dependencies are ready.
+
+## Onboarding Flow (First-Run Experience)
+
+**Deferred from:** Phase 5b
+**Blocked by:** Real integrations need to be wired up first
+
+When Settings aren't configured (no vault path, no recordings directory, no calendar connected), the dashboard is empty with no guidance. A first-run onboarding flow should:
+
+- Detect unconfigured state on app launch
+- Walk the user through: recordings directory selection, Obsidian vault path, Zoho Calendar OAuth, Zoom OAuth
+- Show progress indicators for each setup step
+- Allow skipping optional integrations (calendar, Zoom) with a "configure later" option
+- After completion, transition smoothly into the main dashboard
+- Re-accessible from Settings ("Re-run setup wizard")
+
+**Design note:** Should feel lightweight and integrated — not a blocking modal wizard. Consider an inline setup checklist that lives in the dashboard until all steps are complete or dismissed.
+
+## Bulk Operations
+
+**Deferred from:** Phase 5b
+
+- Delete multiple meetings at once (checkbox select + bulk delete)
+- Reprocess all failed meetings in one action
+- Bulk speaker label correction (apply corrections across multiple meetings)
+
+## Todoist Completion Sync
+
+**Deferred from:** Phase 2 (core pipeline design)
+
+Sync task completion status back from Todoist to vault notes. Currently one-way only (vault → Todoist).
+
+## Non-Zoom Platform Recording
+
+**Deferred from:** App shell design
+
+Local audio/screen capture for Teams, Google Meet, Zoho Meet. Requires WASAPI or virtual audio cable strategy. See app-shell design doc for full context.

--- a/src/lib/components/DetailPanel.svelte
+++ b/src/lib/components/DetailPanel.svelte
@@ -9,7 +9,7 @@
   import MeetingNotes from "./MeetingNotes.svelte";
   import MeetingTranscript from "./MeetingTranscript.svelte";
   import ScreenshotGallery from "./ScreenshotGallery.svelte";
-  import PipelineStatusBadge from "./PipelineStatusBadge.svelte";
+  import PipelineDots from "./PipelineDots.svelte";
 
   interface Props {
     meetingId: string;
@@ -106,7 +106,7 @@
       <MeetingHeader meeting={detail.summary} showBack={false} />
 
       <div class="flex items-center gap-3" style="margin-top: 12px;">
-        <PipelineStatusBadge status={detail.summary.pipeline_status} />
+        <PipelineDots status={detail.summary.pipeline_status} recordingPath={detail.summary.recording_path} />
       </div>
 
       <RetryBanner meeting={detail.summary} />

--- a/src/lib/components/MeetingRow.svelte
+++ b/src/lib/components/MeetingRow.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { MeetingSummary } from "../tauri";
-  import PipelineStatusBadge from "./PipelineStatusBadge.svelte";
+  import PipelineDots from "./PipelineDots.svelte";
 
   interface Props {
     meeting: MeetingSummary;
@@ -100,6 +100,6 @@
         {/if}
       </div>
     </div>
-    <PipelineStatusBadge status={meeting.pipeline_status} />
+    <PipelineDots status={meeting.pipeline_status} recordingPath={meeting.recording_path} />
   </div>
 </a>

--- a/src/lib/components/PipelineDots.svelte
+++ b/src/lib/components/PipelineDots.svelte
@@ -1,0 +1,198 @@
+<script lang="ts">
+  import type { PipelineStatus } from "../tauri";
+  import { retryProcessing } from "../tauri";
+
+  interface Props {
+    status: PipelineStatus;
+    recordingPath?: string | null;
+  }
+
+  let { status, recordingPath = null }: Props = $props();
+
+  const stages = ["merge", "frames", "transcribe", "diarize", "analyze", "export"] as const;
+  type Stage = (typeof stages)[number];
+
+  let expanded = $state(false);
+
+  let ariaLabel = $derived.by(() => {
+    const parts = stages.map((s) => {
+      const st = status[s];
+      if (st.error) return `${s}: failed`;
+      if (st.completed) return `${s}: completed`;
+      return `${s}: pending`;
+    });
+    return `Pipeline stages: ${parts.join(", ")}`;
+  });
+
+  function dotColor(stage: Stage): string {
+    const st = status[stage];
+    if (st.error) return "#D06850";
+    if (st.completed) return "#A8A078";
+    return "#464440";
+  }
+
+  function stageIcon(stage: Stage): string {
+    const st = status[stage];
+    if (st.error) return "\u2717";
+    if (st.completed) return "\u2713";
+    return "\u2022";
+  }
+
+  function stageIconColor(stage: Stage): string {
+    const st = status[stage];
+    if (st.error) return "#D06850";
+    if (st.completed) return "#A8A078";
+    return "#585650";
+  }
+
+  function formatTimestamp(ts: string | null): string | null {
+    if (!ts) return null;
+    try {
+      const d = new Date(ts);
+      return d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+    } catch {
+      return ts;
+    }
+  }
+
+  function toggleExpanded(e: MouseEvent) {
+    e.stopPropagation();
+    e.preventDefault();
+    expanded = !expanded;
+  }
+
+  function handleDetailClick(e: MouseEvent) {
+    e.stopPropagation();
+    e.preventDefault();
+  }
+
+  async function handleRetry(e: MouseEvent, stage: Stage) {
+    e.stopPropagation();
+    e.preventDefault();
+    if (recordingPath) {
+      await retryProcessing(recordingPath, stage);
+    }
+  }
+</script>
+
+<div style="display: flex; flex-direction: column; align-items: flex-end;">
+  <!-- svelte-ignore a11y_role_has_required_aria_properties -->
+  <button
+    type="button"
+    onclick={toggleExpanded}
+    aria-expanded={expanded}
+    aria-label={ariaLabel}
+    style="
+      display: inline-flex;
+      align-items: center;
+      gap: 3px;
+      padding: 4px 6px;
+      border: none;
+      border-radius: 4px;
+      background: transparent;
+      cursor: pointer;
+      transition: background 120ms ease;
+    "
+    onmouseenter={(e) => {
+      (e.currentTarget as HTMLElement).style.background = 'rgba(168,160,120,0.08)';
+    }}
+    onmouseleave={(e) => {
+      (e.currentTarget as HTMLElement).style.background = 'transparent';
+    }}
+  >
+    {#each stages as stage}
+      <span
+        style="
+          display: inline-block;
+          width: 6px;
+          height: 6px;
+          border-radius: 50%;
+          background: {dotColor(stage)};
+        "
+      ></span>
+    {/each}
+  </button>
+
+  {#if expanded}
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      onclick={handleDetailClick}
+      style="
+        margin-top: 8px;
+        padding: 10px 12px;
+        border-radius: 6px;
+        background: #1A1A18;
+        font-family: 'DM Sans', sans-serif;
+        font-size: 12px;
+        min-width: 240px;
+      "
+    >
+      {#each stages as stage}
+        {@const st = status[stage]}
+        <div
+          style="
+            display: flex;
+            align-items: flex-start;
+            gap: 8px;
+            padding: 4px 0;
+            {stage !== stages[stages.length - 1] ? 'border-bottom: 1px solid rgba(88,86,80,0.2);' : ''}
+          "
+        >
+          <span
+            style="
+              flex-shrink: 0;
+              width: 16px;
+              text-align: center;
+              color: {stageIconColor(stage)};
+              font-size: 13px;
+              line-height: 1.4;
+            "
+          >{stageIcon(stage)}</span>
+
+          <div style="flex: 1; min-width: 0;">
+            <div style="display: flex; align-items: center; justify-content: space-between; gap: 8px;">
+              <span style="color: #D8D5CE; text-transform: capitalize;">{stage}</span>
+              {#if st.completed && st.timestamp}
+                <span style="color: #78756E; font-size: 11px; white-space: nowrap;">
+                  {formatTimestamp(st.timestamp)}
+                </span>
+              {/if}
+            </div>
+            {#if st.error}
+              <div style="color: #D06850; font-size: 11px; margin-top: 2px; word-break: break-word;">
+                {st.error}
+              </div>
+              {#if recordingPath}
+                <button
+                  type="button"
+                  onclick={(e) => handleRetry(e, stage)}
+                  style="
+                    margin-top: 4px;
+                    padding: 2px 8px;
+                    border: 1px solid rgba(208,104,80,0.3);
+                    border-radius: 3px;
+                    background: rgba(208,104,80,0.08);
+                    color: #D06850;
+                    font-family: 'DM Sans', sans-serif;
+                    font-size: 11px;
+                    cursor: pointer;
+                    transition: background 120ms ease;
+                  "
+                  onmouseenter={(e) => {
+                    (e.currentTarget as HTMLElement).style.background = 'rgba(208,104,80,0.18)';
+                  }}
+                  onmouseleave={(e) => {
+                    (e.currentTarget as HTMLElement).style.background = 'rgba(208,104,80,0.08)';
+                  }}
+                >
+                  Retry
+                </button>
+              {/if}
+            {/if}
+          </div>
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/src/lib/components/PipelineDots.svelte
+++ b/src/lib/components/PipelineDots.svelte
@@ -15,6 +15,11 @@
   let expanded = $state(false);
   let retrying = $state<string | null>(null);
 
+  function getRecordingDir(filePath: string): string {
+    const lastSep = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
+    return lastSep > 0 ? filePath.substring(0, lastSep) : filePath;
+  }
+
   let ariaLabel = $derived.by(() => {
     const parts = stages.map((s) => {
       const st = status[s];
@@ -80,7 +85,9 @@
     if (!recordingPath || retrying) return;
     retrying = stage;
     try {
-      await retryProcessing(recordingPath, stage);
+      await retryProcessing(getRecordingDir(recordingPath), stage);
+    } catch (e) {
+      console.error("Retry failed:", e);
     } finally {
       retrying = null;
     }
@@ -88,7 +95,6 @@
 </script>
 
 <div style="display: flex; flex-direction: column; align-items: flex-end;">
-  <!-- svelte-ignore a11y_role_has_required_aria_properties -->
   <button
     type="button"
     onclick={toggleExpanded}

--- a/src/lib/components/PipelineDots.svelte
+++ b/src/lib/components/PipelineDots.svelte
@@ -13,6 +13,7 @@
   type Stage = (typeof stages)[number];
 
   let expanded = $state(false);
+  let retrying = $state<string | null>(null);
 
   let ariaLabel = $derived.by(() => {
     const parts = stages.map((s) => {
@@ -66,11 +67,22 @@
     e.preventDefault();
   }
 
+  function dotTitle(stage: Stage): string {
+    const s = status[stage];
+    if (s.error) return `${stage}: ${s.error}`;
+    if (s.completed) return `${stage}: done`;
+    return `${stage}: pending`;
+  }
+
   async function handleRetry(e: MouseEvent, stage: Stage) {
     e.stopPropagation();
     e.preventDefault();
-    if (recordingPath) {
+    if (!recordingPath || retrying) return;
+    retrying = stage;
+    try {
       await retryProcessing(recordingPath, stage);
+    } finally {
+      retrying = null;
     }
   }
 </script>
@@ -102,6 +114,7 @@
   >
     {#each stages as stage}
       <span
+        title={dotTitle(stage)}
         style="
           display: inline-block;
           width: 6px;
@@ -166,6 +179,7 @@
               {#if recordingPath}
                 <button
                   type="button"
+                  disabled={retrying !== null}
                   onclick={(e) => handleRetry(e, stage)}
                   style="
                     margin-top: 4px;
@@ -186,7 +200,7 @@
                     (e.currentTarget as HTMLElement).style.background = 'rgba(208,104,80,0.08)';
                   }}
                 >
-                  Retry
+                  {retrying === stage ? '...' : 'Retry'}
                 </button>
               {/if}
             {/if}

--- a/src/lib/components/RecordingSettings.svelte
+++ b/src/lib/components/RecordingSettings.svelte
@@ -18,7 +18,7 @@
     <input
       type="text"
       value={$settings.recordingsFolder}
-      onblur={async (e) => { await saveSetting("recordingsFolder", e.currentTarget.value); await resetMeetings(); }}
+      onblur={async (e) => { const newValue = e.currentTarget.value; if (newValue !== $settings.recordingsFolder) { await saveSetting("recordingsFolder", newValue); await resetMeetings(); } }}
       style="flex:1;background:#282826;border:1px solid #262624;border-radius:6px;padding:6px 12px;font-size:15px;color:#D8D5CE;font-family:'DM Sans',sans-serif;outline:none;"
       placeholder="Path to store recordings"
     />

--- a/src/lib/components/RecordingSettings.svelte
+++ b/src/lib/components/RecordingSettings.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
   import { settings, saveSetting } from "../stores/settings";
+  import { resetMeetings } from "../stores/meetings";
   import { open } from "@tauri-apps/plugin-dialog";
 
   async function browseRecordingsFolder() {
     const selected = await open({ directory: true, multiple: false });
     if (selected) {
       await saveSetting("recordingsFolder", selected as string);
+      await resetMeetings();
     }
   }
 </script>
@@ -16,7 +18,7 @@
     <input
       type="text"
       value={$settings.recordingsFolder}
-      onblur={(e) => saveSetting("recordingsFolder", e.currentTarget.value)}
+      onblur={async (e) => { await saveSetting("recordingsFolder", e.currentTarget.value); await resetMeetings(); }}
       style="flex:1;background:#282826;border:1px solid #262624;border-radius:6px;padding:6px 12px;font-size:15px;color:#D8D5CE;font-family:'DM Sans',sans-serif;outline:none;"
       placeholder="Path to store recordings"
     />

--- a/src/lib/components/RetryBanner.svelte
+++ b/src/lib/components/RetryBanner.svelte
@@ -24,11 +24,16 @@
 
   let shouldShow = $derived(failedStage !== null || missingOutputs);
 
+  function getRecordingDir(filePath: string): string {
+    const lastSep = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
+    return lastSep > 0 ? filePath.substring(0, lastSep) : filePath;
+  }
+
   async function retry(fromStage?: string) {
     if (!meeting.recording_path || retrying) return;
     retrying = true;
     try {
-      await retryProcessing(meeting.recording_path, fromStage);
+      await retryProcessing(getRecordingDir(meeting.recording_path), fromStage);
     } catch (e) {
       console.error("Retry failed:", e);
     } finally {

--- a/src/lib/components/VaultSettings.svelte
+++ b/src/lib/components/VaultSettings.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
   import { settings, saveSetting } from "../stores/settings";
+  import { resetMeetings } from "../stores/meetings";
   import { open } from "@tauri-apps/plugin-dialog";
 
   async function browseVaultPath() {
     const selected = await open({ directory: true, multiple: false });
     if (selected) {
       await saveSetting("vaultPath", selected as string);
+      await resetMeetings();
     }
   }
 
@@ -20,7 +22,7 @@
       <input
         type="text"
         value={$settings.vaultPath}
-        onblur={(e) => saveSetting("vaultPath", e.currentTarget.value)}
+        onblur={async (e) => { await saveSetting("vaultPath", e.currentTarget.value); await resetMeetings(); }}
         style="flex:1;background:#282826;border:1px solid #262624;border-radius:6px;padding:6px 12px;font-size:15px;color:#D8D5CE;font-family:'DM Sans',sans-serif;outline:none;"
         placeholder="Path to Obsidian vault"
       />

--- a/src/lib/components/VaultSettings.svelte
+++ b/src/lib/components/VaultSettings.svelte
@@ -22,7 +22,7 @@
       <input
         type="text"
         value={$settings.vaultPath}
-        onblur={async (e) => { await saveSetting("vaultPath", e.currentTarget.value); await resetMeetings(); }}
+        onblur={async (e) => { const newValue = e.currentTarget.value; if (newValue !== $settings.vaultPath) { await saveSetting("vaultPath", newValue); await resetMeetings(); } }}
         style="flex:1;background:#282826;border:1px solid #262624;border-radius:6px;padding:6px 12px;font-size:15px;color:#D8D5CE;font-family:'DM Sans',sans-serif;outline:none;"
         placeholder="Path to Obsidian vault"
       />
@@ -40,15 +40,15 @@
   <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:12px;">
     <label style="display:block;">
       <span style={labelStyle}>Meetings Folder</span>
-      <input type="text" value={$settings.meetingsFolder} onblur={(e) => saveSetting("meetingsFolder", e.currentTarget.value)} style={inputStyle} />
+      <input type="text" value={$settings.meetingsFolder} onblur={async (e) => { const newValue = e.currentTarget.value; if (newValue !== $settings.meetingsFolder) { await saveSetting("meetingsFolder", newValue); await resetMeetings(); } }} style={inputStyle} />
     </label>
     <label style="display:block;">
       <span style={labelStyle}>People Folder</span>
-      <input type="text" value={$settings.peopleFolder} onblur={(e) => saveSetting("peopleFolder", e.currentTarget.value)} style={inputStyle} />
+      <input type="text" value={$settings.peopleFolder} onblur={async (e) => { const newValue = e.currentTarget.value; if (newValue !== $settings.peopleFolder) { await saveSetting("peopleFolder", newValue); await resetMeetings(); } }} style={inputStyle} />
     </label>
     <label style="display:block;">
       <span style={labelStyle}>Companies Folder</span>
-      <input type="text" value={$settings.companiesFolder} onblur={(e) => saveSetting("companiesFolder", e.currentTarget.value)} style={inputStyle} />
+      <input type="text" value={$settings.companiesFolder} onblur={async (e) => { const newValue = e.currentTarget.value; if (newValue !== $settings.companiesFolder) { await saveSetting("companiesFolder", newValue); await resetMeetings(); } }} style={inputStyle} />
     </label>
   </div>
 </div>

--- a/src/lib/stores/meetings.ts
+++ b/src/lib/stores/meetings.ts
@@ -28,6 +28,9 @@ const initial: MeetingsState = {
 
 export const meetings = writable<MeetingsState>({ ...initial });
 
+/** Incremented when settings change so GraphView knows to refetch. */
+export const graphDataVersion = writable(0);
+
 // ---------------------------------------------------------------------------
 // Filter state
 // ---------------------------------------------------------------------------
@@ -265,6 +268,7 @@ export async function resetMeetings(): Promise<void> {
   meetings.set({ ...initial });
   activeFilters.set({ ...initialFilters });
   filterOptions.set({ companies: [], participants: [], platforms: [] });
+  graphDataVersion.update(v => v + 1);
   await loadMeetings();
   await loadFilterOptions();
 }

--- a/src/lib/stores/meetings.ts
+++ b/src/lib/stores/meetings.ts
@@ -259,3 +259,12 @@ export function destroyMeetingsListener(): void {
     unlistenPipeline = null;
   }
 }
+
+/** Reset meetings state and reload. Called when settings paths change. */
+export async function resetMeetings(): Promise<void> {
+  meetings.set({ ...initial });
+  activeFilters.set({ ...initialFilters });
+  filterOptions.set({ companies: [], participants: [], platforms: [] });
+  await loadMeetings();
+  await loadFilterOptions();
+}

--- a/src/routes/Dashboard.svelte
+++ b/src/routes/Dashboard.svelte
@@ -58,14 +58,20 @@
   onDestroy(() => {
     destroyRecorderListener();
     destroyMeetingsListener();
+    if (searchTimer) clearTimeout(searchTimer);
   });
 
+  let searchTimer: ReturnType<typeof setTimeout> | null = null;
+
   function handleSearch(query: string) {
-    if (query.trim()) {
-      search(query.trim());
-    } else {
+    if (searchTimer) clearTimeout(searchTimer);
+    if (!query.trim()) {
       clearSearch();
+      return;
     }
+    searchTimer = setTimeout(() => {
+      search(query.trim());
+    }, 300);
   }
 
   function handleLoadMore() {

--- a/src/routes/Dashboard.svelte
+++ b/src/routes/Dashboard.svelte
@@ -14,6 +14,7 @@
     initMeetingsListener,
     destroyMeetingsListener,
   } from "../lib/stores/meetings";
+  import { settings } from "../lib/stores/settings";
   import { initRecorderListener, destroyRecorderListener } from "../lib/stores/recorder";
   import RecordingStatusBar from "../lib/components/RecordingStatusBar.svelte";
   import SearchBar from "../lib/components/SearchBar.svelte";
@@ -185,6 +186,31 @@
           "
         >
           {$meetings.error}
+        </div>
+      {/if}
+
+      {#if !$settings.recordingsFolder}
+        <div
+          class="mt-4 p-4 rounded-lg"
+          style="
+            background: rgba(180,165,130,0.08);
+            font-family: 'DM Sans', sans-serif;
+            font-size: 14.5px;
+            color: #B4A882;
+            text-align: center;
+          "
+        >
+          <p style="margin: 0 0 8px 0;">No recordings folder configured</p>
+          <a
+            href="#settings"
+            style="
+              color: #A8A078;
+              text-decoration: underline;
+              font-weight: 600;
+            "
+          >
+            Configure in Settings
+          </a>
         </div>
       {/if}
 

--- a/src/routes/GraphView.svelte
+++ b/src/routes/GraphView.svelte
@@ -509,7 +509,15 @@
   {#if loading}
     <div class="graph-message">Loading graph...</div>
   {:else if error}
-    <div class="graph-message graph-error">{error}</div>
+    <div class="graph-message graph-error">
+      {error}
+      {#if error?.includes("No recordings folder")}
+        <br />
+        <a href="#settings" style="color: #A8A078; text-decoration: underline; font-weight: 600; margin-top: 8px; display: inline-block;">
+          Configure in Settings
+        </a>
+      {/if}
+    </div>
   {:else if nodes.length === 0}
     <div class="graph-message">No meeting data to display</div>
   {:else}

--- a/src/routes/GraphView.svelte
+++ b/src/routes/GraphView.svelte
@@ -10,6 +10,7 @@
     type SimulationLinkDatum,
   } from "d3-force";
   import { settings } from "../lib/stores/settings";
+  import { graphDataVersion } from "../lib/stores/meetings";
   import { get } from "svelte/store";
   import { getGraphData, type GraphNode, type GraphEdge } from "../lib/tauri";
   import { USE_DUMMY_DATA, DUMMY_GRAPH_DATA } from "../lib/dummy-data";
@@ -417,9 +418,12 @@
     });
   });
 
-  onMount(async () => {
-    updateSize();
-    window.addEventListener("resize", updateSize);
+  // Track the initial version so the $effect only refetches on subsequent changes
+  let initialGraphVersion = get(graphDataVersion);
+
+  async function loadGraphData() {
+    loading = true;
+    error = null;
 
     let data;
     if (USE_DUMMY_DATA) {
@@ -445,6 +449,11 @@
 
     try {
       if (data.nodes.length === 0) {
+        allNodes = [];
+        allLinks = [];
+        nodes = [];
+        links = [];
+        if (simulation) { simulation.stop(); simulation = null; }
         loading = false;
         return;
       }
@@ -471,6 +480,8 @@
       nodes = [...allNodes];
       links = [...allLinks];
 
+      if (simulation) simulation.stop();
+
       simulation = forceSimulation<SimNode>(nodes)
         .force(
           "link",
@@ -485,7 +496,6 @@
         .alphaDecay(0.03)
         .velocityDecay(0.4)
         .on("tick", () => {
-          // Only trigger Svelte reactivity update, don't create new arrays
           nodes = nodes;
           links = links;
         });
@@ -495,6 +505,21 @@
       error = e instanceof Error ? e.message : String(e);
       loading = false;
     }
+  }
+
+  // Watch graphDataVersion — refetch graph data when settings change (skip initial)
+  $effect(() => {
+    const version = $graphDataVersion;
+    if (version !== initialGraphVersion) {
+      initialGraphVersion = version;
+      loadGraphData();
+    }
+  });
+
+  onMount(async () => {
+    updateSize();
+    window.addEventListener("resize", updateSize);
+    await loadGraphData();
   });
 
   onDestroy(() => {

--- a/src/routes/MeetingDetail.svelte
+++ b/src/routes/MeetingDetail.svelte
@@ -10,7 +10,7 @@
   import MeetingNotes from "../lib/components/MeetingNotes.svelte";
   import MeetingTranscript from "../lib/components/MeetingTranscript.svelte";
   import ScreenshotGallery from "../lib/components/ScreenshotGallery.svelte";
-  import PipelineStatusBadge from "../lib/components/PipelineStatusBadge.svelte";
+  import PipelineDots from "../lib/components/PipelineDots.svelte";
 
   interface Props {
     meetingId: string;
@@ -115,7 +115,7 @@
       <MeetingHeader meeting={detail.summary} />
 
       <div class="flex items-center gap-3">
-        <PipelineStatusBadge status={detail.summary.pipeline_status} />
+        <PipelineDots status={detail.summary.pipeline_status} recordingPath={detail.summary.recording_path} />
       </div>
 
       <RetryBanner meeting={detail.summary} />


### PR DESCRIPTION
## Summary
- Add `resetMeetings()` store function + wire Settings path changes to trigger meetings reload
- Add 300ms search debounce to Dashboard
- Replace pipeline status badge with compact dot indicators (6 dots per meeting card) with expandable stage detail, retry buttons, and per-dot tooltips
- Add actionable error states ("Configure in Settings" links) to Dashboard and Graph View
- Wire PipelineDots into DetailPanel for consistency
- Verify all TypeScript interfaces align with Rust backend serialization

## Test Plan
- [ ] Vite production build passes
- [ ] Dummy data mode: meetings list loads, pipeline dots visible on cards
- [ ] Click dots to expand stage detail with timestamps and retry buttons
- [ ] Search debounces (type quickly, single IPC call after 300ms)
- [ ] Change recordings folder in Settings → meetings list reloads
- [ ] Change vault path in Settings → meetings list reloads
- [ ] With no recordings folder configured → "Configure in Settings" banner shown
- [ ] Graph view with no recordings folder → error with Settings link
- [ ] Detail panel shows pipeline dots with retry capability

🤖 Generated with [Claude Code](https://claude.com/claude-code)