### PR TITLE
Phase 5c: Theme, Calendar, Speaker Correction, Briefings

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -15,23 +15,23 @@ recap/
 ├── src/
 │   ├── main.ts                            # Svelte mount point
 │   ├── app.css                            # Tailwind base + Warm Ink dark theme
-│   ├── App.svelte                         # Hash routing, top nav bar, OAuth listeners
+│   ├── App.svelte                         # Hash routing, top nav bar, OAuth listeners, calendar sync
 │   ├── routes/
 │   │   ├── Dashboard.svelte               # Split-panel: FilterSidebar | MeetingList + DetailPanel
 │   │   ├── MeetingDetail.svelte           # Full meeting view: player, notes, transcript, screenshots
+│   │   ├── Calendar.svelte                # Calendar view with upcoming/past events
 │   │   ├── GraphView.svelte               # d3-force graph + controls panel + sidebar
 │   │   └── Settings.svelte                # Provider connections, vault, recording, WhisperX config
 │   └── lib/
 │       ├── tauri.ts                       # Tauri IPC wrappers + TypeScript types for commands
-│       ├── assets.ts                      # convertFileSrc helper for local asset URLs
-│       ├── markdown.ts                    # Obsidian-flavored markdown → HTML (wikilinks, callouts)
+│       ├── assets.ts / markdown.ts         # Asset URL helper + Obsidian-flavored markdown → HTML
 │       ├── dummy-data.ts                  # Dev-only dummy data gated by VITE_DUMMY_DATA env var
 │       ├── stores/
 │       │   ├── credentials.ts             # Per-provider OAuth token state
 │       │   ├── settings.ts                # App settings with Tauri persistence
 │       │   ├── meetings.ts                # Meeting list, pagination, filters, resetMeetings, graphDataVersion
 │       │   └── recorder.ts                # Recording state machine (idle → recording → processing)
-│       └── components/                    # 27 Svelte components (see Key Relationships)
+│       └── components/                    # 30 Svelte components (see Key Relationships)
 ├── recap/                                 # Python ML pipeline
 │   ├── pipeline.py                        # Stage-tracked orchestrator with status.json
 │   ├── transcribe.py / frames.py          # WhisperX transcription + video frame extraction
@@ -43,6 +43,9 @@ recap/
 │   ├── lib.rs                             # Plugin registration, tray, window state, IPC commands
 │   ├── main.rs                            # Tauri entry point
 │   ├── meetings.rs                        # Filesystem scanning, list/detail/search/filter/graph IPC
+│   ├── calendar.rs                        # Zoho Calendar API, cache, event-recording matching
+│   ├── briefing.rs                        # Claude CLI briefing generation with caching
+│   ├── notifications.rs                   # Pre-meeting desktop notification trigger
 │   ├── oauth.rs / credentials.rs          # 5-provider OAuth + Stronghold credential store
 │   ├── deep_link.rs                       # recap:// URI handler for OAuth callbacks
 │   ├── sidecar.rs / diagnostics.rs        # Pipeline invocation + NVENC/ffmpeg checks
@@ -52,30 +55,29 @@ recap/
 │       ├── capture.rs / monitor.rs        # WASAPI audio + Graphics Capture screen recording
 │       ├── types.rs                       # RecorderState enum + shared types
 │       └── zoom.rs                        # Zoom meeting metadata extraction
+├── prompts/                               # Claude prompt templates (analysis + briefing)
 ├── docs/plans/                            # Design specs + implementation plans per phase
-├── prompts/meeting_analysis.md            # Claude prompt template for meeting analysis
 ├── scripts/build-sidecar.py               # Packages Python pipeline as Tauri sidecar
 ├── tests/                                 # Python tests (pytest): pipeline, transcribe, vault, etc.
-├── config.example.yaml                    # Sample pipeline config
-├── vite.config.ts / tsconfig.json         # Vite + TypeScript build config
 └── package.json / pyproject.toml          # JS + Python dependency manifests
 ```
 
 ## Key Relationships
 
-- `App.svelte` routes `#meeting/{id}` → MeetingDetail, `#graph` → GraphView, `#settings` → Settings
+- `App.svelte` routes `#meeting/{id}` → MeetingDetail, `#calendar` → Calendar, `#graph` → GraphView, `#settings` → Settings; auto-syncs calendar on focus (debounced 15 min)
 - `Dashboard` renders FilterSidebar + MeetingList; clicking a row opens inline DetailPanel
-- `MeetingDetail` composes Header, Player, Notes, Transcript, ScreenshotGallery, PipelineDots
-- `PipelineDots` shows 6-stage dot indicators with expandable detail + retry; replaces PipelineStatusBadge
+- `MeetingDetail` composes Header, Player, Notes, Transcript, ScreenshotGallery, PipelineDots, SpeakerReview
+- `SpeakerReview` reads `waiting` field from PipelineStatus, writes speaker_labels.json via IPC
+- `BriefingPanel` calls Claude CLI through briefing.rs, results cached per event ID
 - `MeetingTranscript` timestamp clicks seek `MeetingPlayer` (Vidstack) via shared time binding
 - `markdown.ts` renders `[[wikilinks]]` as `<a href="#filter/participant/{name}">` for filtering
-- `meetings.ts` store bridges IPC (list/search/filter) → derived `filteredMeetings`; `graphDataVersion` signals graph refresh
-- `FilterSidebar` drives filter state in meetings store; filters include company, participants, platform
-- `RecordingSettings` / `VaultSettings` call `resetMeetings()` on path changes (with value-change guards)
+- `meetings.ts` store bridges IPC → derived `filteredMeetings`; invalidates briefing cache on pipeline-completed
+- Calendar events matched to recordings via time overlap (calendar.rs ↔ meetings.rs)
+- Pipeline pauses at analyze when no participant list, resumes after speaker review
+- `FilterSidebar` drives filter state; `RecordingSettings`/`VaultSettings` call `resetMeetings()` on path changes
 - `dummy-data.ts` provides mock data when `VITE_DUMMY_DATA=true`; tree-shaken out of prod builds
-- `lib.rs` hides window on close (not quit), saves geometry; quit only via tray context menu
-- `oauth.rs` spawns localhost server for Google/Microsoft; `deep_link.rs` handles `recap://` callbacks
+- `notifications.rs` runs on 60s timer, reads calendar cache + settings, sends desktop notifications within lead time
+- `lib.rs` hides window on close (not quit); `oauth.rs` spawns localhost for Google/Microsoft OAuth
 - `recorder.rs` orchestrates monitor → capture → merge → zoom metadata → sidecar pipeline launch
 - `pipeline.py` writes `status.json` per stage; `--from`/`--only` flags enable retry from any stage
 - `GraphView` integrates GraphControls (d3 force sliders) + GraphSidebar (person/company drill-down)
-- `GraphView` watches `graphDataVersion` to refetch when settings paths change

--- a/docs/plans/future-phases.md
+++ b/docs/plans/future-phases.md
@@ -1,24 +1,48 @@
 # Future Phases — Deferred Features
 
-Features explicitly deferred from current phases. Each should be scoped into its own phase when dependencies are ready.
+Features explicitly deferred from current phases, organized into planned phases.
 
-## Onboarding Flow (First-Run Experience)
+## Phase 6: Recording Expansion
+
+**Dependencies:** Phase 5c calendar integration (for auto-record)
+
+### Non-Zoom Platform Recording
+
+**Deferred from:** App shell design
+
+Local audio/screen capture for Teams, Google Meet, Zoho Meet. Requires WASAPI or virtual audio cable strategy. See app-shell design doc for full context.
+
+### Auto-Record from Calendar
+
+**Deferred from:** Phase 5c
+
+Per-event or per-series auto-record flag stored in calendar cache. When a matching calendar event is approaching and auto-record is on, the recorder prepares capture automatically. Depends on recording expansion — auto-record is most useful once multiple platforms are supported, not just Zoom (which already has meeting detection).
+
+## Phase 7: Onboarding Flow (First-Run Experience)
 
 **Deferred from:** Phase 5b
-**Blocked by:** Real integrations need to be wired up first
+**Blocked by:** Phase 6 — onboarding should cover all recording integrations, not just Zoom
 
 When Settings aren't configured (no vault path, no recordings directory, no calendar connected), the dashboard is empty with no guidance. A first-run onboarding flow should:
 
 - Detect unconfigured state on app launch
-- Walk the user through: recordings directory selection, Obsidian vault path, Zoho Calendar OAuth, Zoom OAuth
+- Walk the user through: recordings directory selection, Obsidian vault path, Zoho Calendar OAuth, platform OAuth (Zoom, Teams, etc.)
 - Show progress indicators for each setup step
-- Allow skipping optional integrations (calendar, Zoom) with a "configure later" option
+- Allow skipping optional integrations (calendar, platforms) with a "configure later" option
 - After completion, transition smoothly into the main dashboard
 - Re-accessible from Settings ("Re-run setup wizard")
 
 **Design note:** Should feel lightweight and integrated — not a blocking modal wizard. Consider an inline setup checklist that lives in the dashboard until all steps are complete or dismissed.
 
-## Bulk Operations
+## Phase 8: Polish
+
+### Responsive Layout
+
+**Deferred from:** Phase 5a
+
+At narrow widths, the detail view player stacks above the tabbed content (no side-by-side). At wider widths, player could sit alongside transcript. Currently fixed layout only.
+
+### Bulk Operations
 
 **Deferred from:** Phase 5b
 
@@ -26,14 +50,14 @@ When Settings aren't configured (no vault path, no recordings directory, no cale
 - Reprocess all failed meetings in one action
 - Bulk speaker label correction (apply corrections across multiple meetings)
 
-## Todoist Completion Sync
+### Todoist Completion Sync
 
 **Deferred from:** Phase 2 (core pipeline design)
 
 Sync task completion status back from Todoist to vault notes. Currently one-way only (vault → Todoist).
 
-## Non-Zoom Platform Recording
+### Light Mode
 
-**Deferred from:** App shell design
+**Deferred from:** Phase 5a
 
-Local audio/screen capture for Teams, Google Meet, Zoho Meet. Requires WASAPI or virtual audio cable strategy. See app-shell design doc for full context.
+Optional light mode toggle. Phase 5a/5c are dark-mode only. CSS custom properties in app.css make this straightforward — define a second set of token values under a `.light` class or `prefers-color-scheme` media query.

--- a/prompts/meeting_briefing.md
+++ b/prompts/meeting_briefing.md
@@ -1,0 +1,29 @@
+You are preparing a pre-meeting briefing. Given notes from past meetings with the same company or participants, produce a structured JSON prep brief.
+
+## Upcoming Meeting
+
+Title: {{title}}
+Participants: {{participants}}
+Time: {{time}}
+
+## Past Meeting Notes
+
+{{past_notes}}
+
+## Instructions
+
+Produce a JSON object with exactly these fields:
+
+1. **topics** — array of strings: ongoing discussion threads and recurring themes across past meetings. Focus on what's still active or unresolved.
+
+2. **action_items** — array of {assignee, description, from_meeting} objects: open items attributed to upcoming meeting attendees. from_meeting is the meeting title where the item was assigned.
+
+3. **context** — string: meeting frequency, how long you've been meeting with these people, any notable patterns.
+
+4. **relationship_summary** — string: working relationship dynamics, communication style, what this person or group cares about most.
+
+5. **first_meeting** — boolean: true if no past meeting notes were provided.
+
+Keep each field concise. Use bullet points within strings, not paragraphs. Focus on what's actionable for the upcoming meeting.
+
+Output ONLY valid JSON. No markdown fences, no explanation, no preamble.

--- a/recap/pipeline.py
+++ b/recap/pipeline.py
@@ -10,7 +10,7 @@ import subprocess
 from recap.analyze import analyze
 from recap.config import RecapConfig
 from recap.frames import extract_frames
-from recap.models import MeetingMetadata
+from recap.models import MeetingMetadata, TranscriptResult
 from recap.todoist import create_tasks, save_retry_file
 from recap.transcribe import transcribe
 from recap.vault import find_previous_meeting, write_meeting_note, write_profile_stubs, slugify
@@ -93,6 +93,17 @@ def _get_audio_duration(path: pathlib.Path) -> float:
     except (ValueError, OSError):
         logger.warning("Could not determine audio duration, defaulting to 0")
         return 0.0
+
+
+def _apply_speaker_labels(transcript: TranscriptResult, labels_path: pathlib.Path) -> TranscriptResult:
+    """Apply speaker label corrections from a JSON mapping file."""
+    if not labels_path.exists():
+        return transcript
+    labels = json.loads(labels_path.read_text())
+    for utterance in transcript.utterances:
+        if utterance.speaker in labels:
+            utterance.speaker = labels[utterance.speaker]
+    return transcript
 
 
 def run_pipeline(
@@ -183,6 +194,11 @@ def run_pipeline(
         _save_status(working_dir, status, recording_dest)
         logger.info("No participants available — pausing for speaker review")
         return {"paused": True, "waiting_at": "analyze"}
+
+    # Apply speaker label corrections if available
+    labels_path = working_dir / "speaker_labels.json"
+    if transcript is not None and isinstance(transcript, TranscriptResult):
+        transcript = _apply_speaker_labels(transcript, labels_path)
 
     # Analyze with Claude
     analysis = None

--- a/recap/pipeline.py
+++ b/recap/pipeline.py
@@ -33,7 +33,7 @@ def _load_status(working_dir: pathlib.Path) -> dict:
     if status_path.exists():
         return json.loads(status_path.read_text())
     return {
-        stage: {"completed": False, "timestamp": None, "error": None}
+        stage: {"completed": False, "timestamp": None, "error": None, "waiting": None}
         for stage in PIPELINE_STAGES
     }
 
@@ -57,7 +57,13 @@ def _mark_stage(status: dict, stage: str, completed: bool, error: str | None = N
         "completed": completed,
         "timestamp": datetime.now().isoformat() if completed else None,
         "error": error,
+        "waiting": None,
     }
+
+
+def _mark_waiting(status: dict, stage: str, reason: str) -> None:
+    """Set a waiting state on a stage (e.g. awaiting speaker review)."""
+    status[stage]["waiting"] = reason
 
 
 def _should_run(stage: str, status: dict, from_stage: str | None, only_stage: str | None) -> bool:

--- a/recap/pipeline.py
+++ b/recap/pipeline.py
@@ -96,7 +96,7 @@ def _get_audio_duration(path: pathlib.Path) -> float:
 
 
 def _apply_speaker_labels(transcript: TranscriptResult, labels_path: pathlib.Path) -> TranscriptResult:
-    """Apply speaker label corrections from a JSON mapping file."""
+    """Apply speaker label corrections from JSON file. Mutates transcript.utterances in place."""
     if not labels_path.exists():
         return transcript
     labels = json.loads(labels_path.read_text())
@@ -193,7 +193,7 @@ def run_pipeline(
         _mark_waiting(status, "analyze", "speaker_review")
         _save_status(working_dir, status, recording_dest)
         logger.info("No participants available — pausing for speaker review")
-        return {"paused": True, "waiting_at": "analyze"}
+        return {**results, "paused": True, "waiting_at": "analyze"}
 
     # Apply speaker label corrections if available
     labels_path = working_dir / "speaker_labels.json"

--- a/recap/pipeline.py
+++ b/recap/pipeline.py
@@ -177,6 +177,13 @@ def run_pipeline(
             _save_status(working_dir, status, recording_dest)
     results["frames"] = [f.path for f in frames]
 
+    # Pause for speaker review if no participants are available
+    if not metadata.participants:
+        _mark_waiting(status, "analyze", "speaker_review")
+        _save_status(working_dir, status, recording_dest)
+        logger.info("No participants available — pausing for speaker review")
+        return {"paused": True, "waiting_at": "analyze"}
+
     # Analyze with Claude
     analysis = None
     if _should_run("analyze", status, from_stage, only_stage):

--- a/src-tauri/src/briefing.rs
+++ b/src-tauri/src/briefing.rs
@@ -25,6 +25,14 @@ pub struct BriefingActionItem {
     pub from_meeting: String,
 }
 
+/// Wrapper for cached briefing data, storing participants for structured invalidation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CachedBriefing {
+    participants: Vec<String>,
+    briefing: Briefing,
+    generated_at: String,
+}
+
 // ---------------------------------------------------------------------------
 // Cache helpers
 // ---------------------------------------------------------------------------
@@ -45,15 +53,24 @@ fn cache_path_for(app: &tauri::AppHandle, event_id: &str) -> PathBuf {
 
 fn read_cached_briefing(path: &Path) -> Option<Briefing> {
     let content = std::fs::read_to_string(path).ok()?;
+    // Try new CachedBriefing format first, fall back to bare Briefing for old cache files
+    if let Ok(cached) = serde_json::from_str::<CachedBriefing>(&content) {
+        return Some(cached.briefing);
+    }
     serde_json::from_str(&content).ok()
 }
 
-fn write_cached_briefing(path: &Path, briefing: &Briefing) -> Result<(), String> {
+fn write_cached_briefing(path: &Path, briefing: &Briefing, participants: &[String]) -> Result<(), String> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
             .map_err(|e| format!("Failed to create briefing cache directory: {}", e))?;
     }
-    let json = serde_json::to_string_pretty(briefing)
+    let cached = CachedBriefing {
+        participants: participants.to_vec(),
+        briefing: briefing.clone(),
+        generated_at: Utc::now().to_rfc3339(),
+    };
+    let json = serde_json::to_string_pretty(&cached)
         .map_err(|e| format!("Failed to serialize briefing: {}", e))?;
     std::fs::write(path, json)
         .map_err(|e| format!("Failed to write briefing cache: {}", e))?;
@@ -413,12 +430,14 @@ pub async fn generate_briefing(
         .map_err(|e| format!("Briefing generation task failed: {}", e))?
         .map_err(|e| format!("Briefing generation failed: {}", e))?;
 
-    // Cache the result
-    write_cached_briefing(&cp, &briefing)?;
+    // Cache the result with participant metadata for structured invalidation
+    write_cached_briefing(&cp, &briefing, &participants)?;
 
     Ok(briefing)
 }
 
+// TODO: Add test for briefing cache invalidation — verify that invalidating
+// by participant name removes the correct cached files and leaves others intact.
 #[tauri::command]
 pub async fn invalidate_briefing_cache(
     app: tauri::AppHandle,
@@ -443,12 +462,19 @@ pub async fn invalidate_briefing_cache(
             continue;
         }
 
-        // Read the cached briefing to check participants
+        // Deserialize cached briefing and check participant array for overlap
         if let Ok(content) = std::fs::read_to_string(&path) {
-            let content_lower = content.to_lowercase();
-            let has_overlap = participant_lower
-                .iter()
-                .any(|p| content_lower.contains(p.as_str()));
+            let has_overlap = if let Ok(cached) = serde_json::from_str::<CachedBriefing>(&content) {
+                // Structured match against the stored participants list
+                let cached_lower: Vec<String> = cached.participants.iter().map(|p| p.to_lowercase()).collect();
+                participant_lower.iter().any(|p| {
+                    cached_lower.iter().any(|cp| cp.contains(p.as_str()) || p.contains(cp.as_str()))
+                })
+            } else {
+                // Legacy cache format without participants — fall back to text search
+                let content_lower = content.to_lowercase();
+                participant_lower.iter().any(|p| content_lower.contains(p.as_str()))
+            };
 
             if has_overlap {
                 let _ = std::fs::remove_file(&path);

--- a/src-tauri/src/briefing.rs
+++ b/src-tauri/src/briefing.rs
@@ -37,7 +37,10 @@ fn cache_dir(app: &tauri::AppHandle) -> PathBuf {
 }
 
 fn cache_path_for(app: &tauri::AppHandle, event_id: &str) -> PathBuf {
-    cache_dir(app).join(format!("{}.json", event_id))
+    let safe_id: String = event_id.chars()
+        .map(|c| if c.is_alphanumeric() || c == '-' || c == '_' { c } else { '_' })
+        .collect();
+    cache_dir(app).join(format!("{}.json", safe_id))
 }
 
 fn read_cached_briefing(path: &Path) -> Option<Briefing> {
@@ -253,27 +256,57 @@ fn build_prompt(
 }
 
 fn call_claude(prompt: &str) -> Result<Briefing, String> {
-    let result = Command::new("claude")
+    use std::io::{Read, Write};
+    use std::time::{Duration, Instant};
+
+    let mut child = Command::new("claude")
         .args(["--print", "--output-format", "json"])
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .spawn()
-        .and_then(|mut child| {
-            use std::io::Write;
-            if let Some(ref mut stdin) = child.stdin {
-                stdin.write_all(prompt.as_bytes())?;
-            }
-            child.wait_with_output()
-        })
         .map_err(|e| format!("Failed to run claude CLI: {}", e))?;
 
-    if !result.status.success() {
-        let stderr = String::from_utf8_lossy(&result.stderr);
-        return Err(format!("Claude CLI returned error: {}", stderr));
+    // Write prompt to stdin and close it
+    if let Some(ref mut stdin) = child.stdin {
+        stdin.write_all(prompt.as_bytes()).ok();
+    }
+    // Drop stdin so the child process sees EOF
+    child.stdin.take();
+
+    // Poll for completion with a 120-second timeout
+    let timeout = Duration::from_secs(120);
+    let start = Instant::now();
+
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if start.elapsed() > timeout {
+                    child.kill().ok();
+                    return Err("Claude CLI timed out after 120 seconds".to_string());
+                }
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Err(e) => return Err(format!("Failed to wait for Claude CLI: {}", e)),
+        }
+    };
+
+    // Read stdout and stderr from the finished process
+    let mut stdout_buf = String::new();
+    let mut stderr_buf = String::new();
+    if let Some(ref mut out) = child.stdout {
+        out.read_to_string(&mut stdout_buf).ok();
+    }
+    if let Some(ref mut err) = child.stderr {
+        err.read_to_string(&mut stderr_buf).ok();
     }
 
-    let stdout = String::from_utf8_lossy(&result.stdout);
+    if !status.success() {
+        return Err(format!("Claude CLI returned error: {}", stderr_buf));
+    }
+
+    let stdout = std::borrow::Cow::Borrowed(stdout_buf.as_str());
 
     // The --output-format json wraps the response; extract the text content
     let output: serde_json::Value = serde_json::from_str(&stdout)

--- a/src-tauri/src/briefing.rs
+++ b/src-tauri/src/briefing.rs
@@ -1,0 +1,427 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use tauri::Manager;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Briefing {
+    pub topics: Vec<String>,
+    pub action_items: Vec<BriefingActionItem>,
+    pub context: String,
+    pub relationship_summary: String,
+    pub first_meeting: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BriefingActionItem {
+    pub assignee: String,
+    pub description: String,
+    pub from_meeting: String,
+}
+
+// ---------------------------------------------------------------------------
+// Cache helpers
+// ---------------------------------------------------------------------------
+
+fn cache_dir(app: &tauri::AppHandle) -> PathBuf {
+    app.path()
+        .app_data_dir()
+        .expect("could not resolve app data dir")
+        .join("briefing_cache")
+}
+
+fn cache_path_for(app: &tauri::AppHandle, event_id: &str) -> PathBuf {
+    cache_dir(app).join(format!("{}.json", event_id))
+}
+
+fn read_cached_briefing(path: &Path) -> Option<Briefing> {
+    let content = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+fn write_cached_briefing(path: &Path, briefing: &Briefing) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create briefing cache directory: {}", e))?;
+    }
+    let json = serde_json::to_string_pretty(briefing)
+        .map_err(|e| format!("Failed to serialize briefing: {}", e))?;
+    std::fs::write(path, json)
+        .map_err(|e| format!("Failed to write briefing cache: {}", e))?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Past meeting lookup
+// ---------------------------------------------------------------------------
+
+/// Find past meeting notes that match the given participants.
+///
+/// Searches the recordings directory for .meeting.json files and the vault
+/// meetings directory for .md files. Returns the content of matched notes.
+fn find_past_meeting_notes(
+    participants: &[String],
+    recordings_dir: &str,
+    vault_meetings_dir: Option<&str>,
+) -> Vec<(String, String)> {
+    let mut notes: Vec<(String, String)> = Vec::new();
+    let lookback = Utc::now() - Duration::days(90);
+
+    // Normalize participant names to lowercase for matching
+    let participant_lower: Vec<String> = participants
+        .iter()
+        .map(|p| p.to_lowercase())
+        .collect();
+
+    // Scan recordings directory for .meeting.json files
+    let recordings_path = PathBuf::from(recordings_dir);
+    if recordings_path.is_dir() {
+        if let Ok(entries) = std::fs::read_dir(&recordings_path) {
+            let mut matched: Vec<(String, String, DateTime<Utc>)> = Vec::new();
+
+            for entry in entries.flatten() {
+                let path = entry.path();
+                let is_meeting_json = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n.ends_with(".meeting.json"))
+                    .unwrap_or(false);
+                if !is_meeting_json {
+                    continue;
+                }
+
+                let content = match std::fs::read_to_string(&path) {
+                    Ok(c) => c,
+                    Err(_) => continue,
+                };
+                let meta: serde_json::Value = match serde_json::from_str(&content) {
+                    Ok(m) => m,
+                    Err(_) => continue,
+                };
+
+                // Check date is within lookback
+                let date_str = meta
+                    .get("date")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let meeting_date = if let Ok(dt) = DateTime::parse_from_rfc3339(date_str) {
+                    dt.with_timezone(&Utc)
+                } else {
+                    continue;
+                };
+                if meeting_date < lookback {
+                    continue;
+                }
+
+                // Check participant overlap
+                let meeting_participants: Vec<String> = meta
+                    .get("participants")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str())
+                            .map(|s| s.to_lowercase())
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                let has_overlap = participant_lower
+                    .iter()
+                    .any(|p| meeting_participants.iter().any(|mp| mp.contains(p.as_str()) || p.contains(mp.as_str())));
+
+                if !has_overlap {
+                    // Also check company name overlap
+                    let company = meta
+                        .get("company")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_lowercase();
+                    if company.is_empty() || !participant_lower.iter().any(|p| p.contains(&company)) {
+                        continue;
+                    }
+                }
+
+                let title = meta
+                    .get("title")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("Untitled")
+                    .to_string();
+
+                matched.push((title, path.display().to_string(), meeting_date));
+            }
+
+            // Sort by date descending and take last 4
+            matched.sort_by(|a, b| b.2.cmp(&a.2));
+            matched.truncate(4);
+
+            // For each matched meeting, try to find its note
+            for (title, json_path, _) in &matched {
+                // Look for a corresponding note file
+                let note_path = json_path.replace(".meeting.json", ".md");
+                if let Ok(content) = std::fs::read_to_string(&note_path) {
+                    notes.push((title.clone(), content));
+                }
+            }
+        }
+    }
+
+    // Also scan vault meetings directory
+    if let Some(vault_dir) = vault_meetings_dir {
+        let vault_path = PathBuf::from(vault_dir);
+        if vault_path.is_dir() {
+            if let Ok(entries) = std::fs::read_dir(&vault_path) {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path.extension().and_then(|e| e.to_str()) != Some("md") {
+                        continue;
+                    }
+
+                    let content = match std::fs::read_to_string(&path) {
+                        Ok(c) => c,
+                        Err(_) => continue,
+                    };
+
+                    // Check if any participant name appears in the note content
+                    let content_lower = content.to_lowercase();
+                    let has_match = participant_lower
+                        .iter()
+                        .any(|p| content_lower.contains(p.as_str()));
+
+                    if has_match {
+                        let title = path
+                            .file_stem()
+                            .and_then(|s| s.to_str())
+                            .unwrap_or("Untitled")
+                            .to_string();
+
+                        // Avoid duplicates
+                        if !notes.iter().any(|(t, _)| t == &title) {
+                            notes.push((title, content));
+                        }
+                    }
+                }
+            }
+
+            // Cap total notes at 4
+            notes.truncate(4);
+        }
+    }
+
+    notes
+}
+
+// ---------------------------------------------------------------------------
+// Claude CLI invocation
+// ---------------------------------------------------------------------------
+
+fn build_prompt(
+    template: &str,
+    title: &str,
+    participants: &[String],
+    time: &str,
+    past_notes: &[(String, String)],
+    event_description: Option<&str>,
+) -> String {
+    let participants_text = participants.join(", ");
+
+    let past_notes_text = if past_notes.is_empty() {
+        "No past meeting notes found for these participants.".to_string()
+    } else {
+        past_notes
+            .iter()
+            .map(|(title, content)| format!("### {}\n\n{}", title, content))
+            .collect::<Vec<_>>()
+            .join("\n\n---\n\n")
+    };
+
+    let mut prompt = template.replace("{{title}}", title);
+    prompt = prompt.replace("{{participants}}", &participants_text);
+    prompt = prompt.replace("{{time}}", time);
+    prompt = prompt.replace("{{past_notes}}", &past_notes_text);
+
+    if let Some(desc) = event_description {
+        prompt.push_str(&format!("\n\n## Event Description\n\n{}", desc));
+    }
+
+    prompt
+}
+
+fn call_claude(prompt: &str) -> Result<Briefing, String> {
+    let result = Command::new("claude")
+        .args(["--print", "--output-format", "json"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            if let Some(ref mut stdin) = child.stdin {
+                stdin.write_all(prompt.as_bytes())?;
+            }
+            child.wait_with_output()
+        })
+        .map_err(|e| format!("Failed to run claude CLI: {}", e))?;
+
+    if !result.status.success() {
+        let stderr = String::from_utf8_lossy(&result.stderr);
+        return Err(format!("Claude CLI returned error: {}", stderr));
+    }
+
+    let stdout = String::from_utf8_lossy(&result.stdout);
+
+    // The --output-format json wraps the response; extract the text content
+    let output: serde_json::Value = serde_json::from_str(&stdout)
+        .map_err(|e| format!("Failed to parse Claude CLI JSON wrapper: {}", e))?;
+
+    // Claude CLI --output-format json returns { "result": "..." } or similar
+    // Try to get the text content from the response
+    let text = if let Some(result_str) = output.get("result").and_then(|v| v.as_str()) {
+        result_str.to_string()
+    } else if let Some(text_str) = output.get("text").and_then(|v| v.as_str()) {
+        text_str.to_string()
+    } else {
+        // Maybe the whole output is the JSON briefing directly
+        stdout.to_string()
+    };
+
+    // Strip markdown code fences if present
+    let cleaned = text.trim();
+    let json_str = if let Some(start) = cleaned.find("```") {
+        let after_fence = &cleaned[start + 3..];
+        let content_start = after_fence.find('\n').map(|i| i + 1).unwrap_or(0);
+        let rest = &after_fence[content_start..];
+        if let Some(end) = rest.find("```") {
+            &rest[..end]
+        } else {
+            rest
+        }
+    } else {
+        cleaned
+    };
+
+    serde_json::from_str(json_str.trim())
+        .map_err(|e| format!("Failed to parse briefing JSON: {}. Raw: {}", e, &json_str[..json_str.len().min(500)]))
+}
+
+// ---------------------------------------------------------------------------
+// Tauri commands
+// ---------------------------------------------------------------------------
+
+#[tauri::command]
+pub async fn generate_briefing(
+    app: tauri::AppHandle,
+    event_id: String,
+    title: String,
+    participants: Vec<String>,
+    time: String,
+    recordings_dir: String,
+    vault_meetings_dir: Option<String>,
+    event_description: Option<String>,
+) -> Result<Briefing, String> {
+    // Check cache first
+    let cp = cache_path_for(&app, &event_id);
+    if let Some(cached) = read_cached_briefing(&cp) {
+        return Ok(cached);
+    }
+
+    // Find past meeting notes
+    let past_notes = find_past_meeting_notes(
+        &participants,
+        &recordings_dir,
+        vault_meetings_dir.as_deref(),
+    );
+
+    // Load prompt template
+    let prompt_template_path = app
+        .path()
+        .resource_dir()
+        .map_err(|e| format!("Could not resolve resource dir: {}", e))?
+        .join("prompts")
+        .join("meeting_briefing.md");
+
+    let template = if prompt_template_path.exists() {
+        std::fs::read_to_string(&prompt_template_path)
+            .map_err(|e| format!("Failed to read prompt template: {}", e))?
+    } else {
+        // Fallback: try relative to executable
+        let exe_dir = std::env::current_exe()
+            .map_err(|e| format!("Could not resolve exe dir: {}", e))?
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_default();
+        let fallback_path = exe_dir.join("prompts").join("meeting_briefing.md");
+        if fallback_path.exists() {
+            std::fs::read_to_string(&fallback_path)
+                .map_err(|e| format!("Failed to read prompt template: {}", e))?
+        } else {
+            // Use inline fallback template
+            include_str!("../../prompts/meeting_briefing.md").to_string()
+        }
+    };
+
+    // Build prompt and call Claude
+    let prompt = build_prompt(
+        &template,
+        &title,
+        &participants,
+        &time,
+        &past_notes,
+        event_description.as_deref(),
+    );
+
+    let briefing = tokio::task::spawn_blocking(move || call_claude(&prompt))
+        .await
+        .map_err(|e| format!("Briefing generation task failed: {}", e))?
+        .map_err(|e| format!("Briefing generation failed: {}", e))?;
+
+    // Cache the result
+    write_cached_briefing(&cp, &briefing)?;
+
+    Ok(briefing)
+}
+
+#[tauri::command]
+pub async fn invalidate_briefing_cache(
+    app: tauri::AppHandle,
+    participant_names: Vec<String>,
+) -> Result<(), String> {
+    let dir = cache_dir(&app);
+    if !dir.is_dir() {
+        return Ok(());
+    }
+
+    let participant_lower: Vec<String> = participant_names
+        .iter()
+        .map(|p| p.to_lowercase())
+        .collect();
+
+    let entries = std::fs::read_dir(&dir)
+        .map_err(|e| format!("Failed to read briefing cache directory: {}", e))?;
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+
+        // Read the cached briefing to check participants
+        if let Ok(content) = std::fs::read_to_string(&path) {
+            let content_lower = content.to_lowercase();
+            let has_overlap = participant_lower
+                .iter()
+                .any(|p| content_lower.contains(p.as_str()));
+
+            if has_overlap {
+                let _ = std::fs::remove_file(&path);
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src-tauri/src/calendar.rs
+++ b/src-tauri/src/calendar.rs
@@ -1,0 +1,267 @@
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use tauri::Manager;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CalendarEvent {
+    pub id: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub start: String,  // ISO 8601
+    pub end: String,    // ISO 8601
+    pub participants: Vec<CalendarParticipant>,
+    pub location: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CalendarParticipant {
+    pub name: String,
+    pub email: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CalendarCache {
+    pub events: Vec<CalendarEvent>,
+    pub last_synced: String,
+}
+
+/// Zoho Calendar API response shape for event listing.
+#[derive(Debug, Deserialize)]
+struct ZohoEventsResponse {
+    events: Option<Vec<ZohoEvent>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ZohoEvent {
+    uid: Option<String>,
+    title: Option<String>,
+    description: Option<String>,
+    dateandtime: Option<ZohoDateAndTime>,
+    attendees: Option<Vec<ZohoAttendee>>,
+    location: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ZohoDateAndTime {
+    start: Option<String>,
+    end: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ZohoAttendee {
+    name: Option<String>,
+    email: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Cache helpers
+// ---------------------------------------------------------------------------
+
+fn cache_path(app: &tauri::AppHandle) -> PathBuf {
+    app.path()
+        .app_data_dir()
+        .expect("could not resolve app data dir")
+        .join("calendar_cache.json")
+}
+
+fn write_cache(path: &Path, cache: &CalendarCache) -> Result<(), String> {
+    let json = serde_json::to_string_pretty(cache)
+        .map_err(|e| format!("Failed to serialize calendar cache: {}", e))?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create cache directory: {}", e))?;
+    }
+    std::fs::write(path, json)
+        .map_err(|e| format!("Failed to write calendar cache: {}", e))?;
+    Ok(())
+}
+
+fn read_cache(path: &Path) -> Result<CalendarCache, String> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("Failed to read calendar cache: {}", e))?;
+    serde_json::from_str(&content)
+        .map_err(|e| format!("Failed to parse calendar cache: {}", e))
+}
+
+// ---------------------------------------------------------------------------
+// Zoho API helpers
+// ---------------------------------------------------------------------------
+
+/// Read the Zoho OAuth access token from the Tauri plugin-store JSON file.
+///
+/// The frontend persists tokens via `@tauri-apps/plugin-stronghold` and also
+/// mirrors the access token into the Tauri plugin-store so Rust-side code can
+/// read it without needing direct Stronghold access.  The store key follows
+/// the pattern `zoho_access_token`.
+///
+/// TODO: If the project migrates to reading directly from Stronghold on the
+/// Rust side, update this helper accordingly.
+fn get_zoho_access_token(app: &tauri::AppHandle) -> Result<String, String> {
+    // The store file is written by the frontend via @tauri-apps/plugin-store.
+    let store_path = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Could not resolve app data dir: {}", e))?
+        .join("settings.json");
+
+    let content = std::fs::read_to_string(&store_path)
+        .map_err(|e| format!("Could not read settings store: {}", e))?;
+    let store_data: serde_json::Value = serde_json::from_str(&content)
+        .map_err(|e| format!("Could not parse settings store: {}", e))?;
+
+    store_data
+        .get("zoho_access_token")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| "Zoho access token not found — please connect Zoho in Settings".to_string())
+}
+
+/// Convert Zoho API event objects into our CalendarEvent structs.
+fn parse_zoho_events(response: ZohoEventsResponse) -> Vec<CalendarEvent> {
+    let zoho_events = match response.events {
+        Some(events) => events,
+        None => return Vec::new(),
+    };
+
+    zoho_events
+        .into_iter()
+        .filter_map(|e| {
+            let dt = e.dateandtime?;
+            Some(CalendarEvent {
+                id: e.uid.unwrap_or_default(),
+                title: e.title.unwrap_or_else(|| "Untitled".to_string()),
+                description: e.description,
+                start: dt.start.unwrap_or_default(),
+                end: dt.end.unwrap_or_default(),
+                participants: e
+                    .attendees
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|a| CalendarParticipant {
+                        name: a.name.unwrap_or_default(),
+                        email: a.email,
+                    })
+                    .collect(),
+                location: e.location,
+            })
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Tauri commands — sync & fetch
+// ---------------------------------------------------------------------------
+
+/// Fetch calendar events from the Zoho Calendar API for a date range.
+///
+/// Reads the Zoho access token from the app store, calls the Zoho Calendar
+/// events endpoint, caches the result locally, and returns the events.
+#[tauri::command]
+pub async fn fetch_calendar_events(
+    app: tauri::AppHandle,
+    start_date: String,
+    end_date: String,
+) -> Result<Vec<CalendarEvent>, String> {
+    let access_token = get_zoho_access_token(&app)?;
+
+    // TODO: Allow the user to configure their Zoho calendar ID in Settings.
+    // For now, use the primary calendar placeholder.
+    let calendar_id = "primary";
+
+    let url = format!(
+        "https://calendar.zoho.com/api/v1/calendars/{}/events?range={},{}",
+        calendar_id, start_date, end_date,
+    );
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(&url)
+        .header("Authorization", format!("Zoho-oauthtoken {}", access_token))
+        .header("Accept", "application/json+large")
+        .send()
+        .await
+        .map_err(|e| format!("Zoho Calendar API request failed: {}", e))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "no body".to_string());
+        return Err(format!(
+            "Zoho Calendar API returned status {}: {}",
+            status, body
+        ));
+    }
+
+    let zoho_response: ZohoEventsResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse Zoho Calendar response: {}", e))?;
+
+    let events = parse_zoho_events(zoho_response);
+
+    // Write to cache
+    let cache = CalendarCache {
+        events: events.clone(),
+        last_synced: Utc::now().to_rfc3339(),
+    };
+    let cp = cache_path(&app);
+    write_cache(&cp, &cache)?;
+
+    Ok(events)
+}
+
+/// Return upcoming meetings from the local cache that start within
+/// `hours_ahead` hours from now.
+#[tauri::command]
+pub async fn get_upcoming_meetings(
+    app: tauri::AppHandle,
+    hours_ahead: f64,
+) -> Result<Vec<CalendarEvent>, String> {
+    let cp = cache_path(&app);
+    let cache = read_cache(&cp)?;
+
+    let now = Utc::now();
+    let horizon = now + Duration::seconds((hours_ahead * 3600.0) as i64);
+
+    let upcoming: Vec<CalendarEvent> = cache
+        .events
+        .into_iter()
+        .filter(|event| {
+            if let Ok(start) = DateTime::parse_from_rfc3339(&event.start) {
+                let start_utc = start.with_timezone(&Utc);
+                start_utc >= now && start_utc <= horizon
+            } else {
+                false
+            }
+        })
+        .collect();
+
+    Ok(upcoming)
+}
+
+/// Sync the calendar by fetching the next 14 days of events.
+#[tauri::command]
+pub async fn sync_calendar(
+    app: tauri::AppHandle,
+) -> Result<CalendarCache, String> {
+    let now = Utc::now();
+    let start_date = now.format("%Y-%m-%dT%H:%M:%S%z").to_string();
+    let end_date = (now + Duration::days(14))
+        .format("%Y-%m-%dT%H:%M:%S%z")
+        .to_string();
+
+    let events = fetch_calendar_events(app.clone(), start_date, end_date).await?;
+
+    // The cache was already written by fetch_calendar_events, but read it back
+    // to return the full CalendarCache struct.
+    let cp = cache_path(&app);
+    read_cache(&cp)
+}

--- a/src-tauri/src/calendar.rs
+++ b/src-tauri/src/calendar.rs
@@ -263,10 +263,12 @@ pub async fn sync_calendar(
 
     let events = fetch_calendar_events(app.clone(), start_date, end_date).await?;
 
-    // The cache was already written by fetch_calendar_events, but read it back
-    // to return the full CalendarCache struct.
-    let cp = cache_path(&app);
-    read_cache(&cp)
+    // Build the CalendarCache directly from the fetched events instead of
+    // re-reading the cache file that fetch_calendar_events just wrote.
+    Ok(CalendarCache {
+        events,
+        last_synced: Utc::now().to_rfc3339(),
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -316,6 +318,23 @@ pub fn match_event_to_recording(
         overlap_minutes >= 5
     } else {
         false
+    }
+}
+
+/// Return the last_synced timestamp from the calendar cache, or null if no cache exists.
+#[tauri::command]
+pub async fn get_calendar_last_synced(
+    app: tauri::AppHandle,
+) -> Result<Option<String>, String> {
+    let cp = cache_path(&app);
+    if !cp.exists() {
+        return Ok(None);
+    }
+    let cache = read_cache(&cp)?;
+    if cache.last_synced.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(cache.last_synced))
     }
 }
 

--- a/src-tauri/src/calendar.rs
+++ b/src-tauri/src/calendar.rs
@@ -1,8 +1,11 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 use tauri::Manager;
+
+use crate::meetings::MeetingSummary;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -264,4 +267,154 @@ pub async fn sync_calendar(
     // to return the full CalendarCache struct.
     let cp = cache_path(&app);
     read_cache(&cp)
+}
+
+// ---------------------------------------------------------------------------
+// Calendar-recording matching (D2)
+// ---------------------------------------------------------------------------
+
+/// Check whether a calendar event overlaps a recording by at least 5 minutes.
+///
+/// `meeting_date` is the recording start time in ISO 8601 (or date string from
+/// the meeting metadata). `duration_seconds` is the recording duration; if
+/// `None`, we assume a 1-hour recording for matching purposes.
+pub fn match_event_to_recording(
+    event: &CalendarEvent,
+    meeting_date: &str,
+    duration_seconds: Option<f64>,
+) -> bool {
+    let event_start = match DateTime::parse_from_rfc3339(&event.start) {
+        Ok(dt) => dt.with_timezone(&Utc),
+        Err(_) => return false,
+    };
+    let event_end = match DateTime::parse_from_rfc3339(&event.end) {
+        Ok(dt) => dt.with_timezone(&Utc),
+        Err(_) => return false,
+    };
+
+    // Try parsing as full RFC 3339 first, then fall back to date-only.
+    let recording_start = if let Ok(dt) = DateTime::parse_from_rfc3339(meeting_date) {
+        dt.with_timezone(&Utc)
+    } else if let Ok(date) = chrono::NaiveDate::parse_from_str(meeting_date, "%Y-%m-%d") {
+        // Assume midnight UTC for date-only strings.
+        date.and_hms_opt(0, 0, 0)
+            .map(|ndt| DateTime::<Utc>::from_naive_utc_and_offset(ndt, Utc))
+            .unwrap_or(return false)
+    } else {
+        return false;
+    };
+
+    let duration_secs = duration_seconds.unwrap_or(3600.0); // default 1 hour
+    let recording_end = recording_start + Duration::seconds(duration_secs as i64);
+
+    // Compute overlap: max(0, min(end1, end2) - max(start1, start2))
+    let overlap_start = event_start.max(recording_start);
+    let overlap_end = event_end.min(recording_end);
+
+    if overlap_end > overlap_start {
+        let overlap_minutes = (overlap_end - overlap_start).num_minutes();
+        overlap_minutes >= 5
+    } else {
+        false
+    }
+}
+
+/// Scan recordings and match them against cached calendar events.
+///
+/// Returns a map of `{ event_id: meeting_id }` for every match found.
+#[tauri::command]
+pub async fn get_calendar_matches(
+    app: tauri::AppHandle,
+    recordings_dir: String,
+) -> Result<HashMap<String, String>, String> {
+    let cp = cache_path(&app);
+    let cache = read_cache(&cp)?;
+
+    let recordings_path = PathBuf::from(&recordings_dir);
+    if !recordings_path.is_dir() {
+        return Err(format!(
+            "Recordings directory does not exist: {}",
+            recordings_dir
+        ));
+    }
+
+    // Scan for .meeting.json files (same pattern as meetings.rs).
+    let entries = std::fs::read_dir(&recordings_path)
+        .map_err(|e| format!("Failed to read recordings directory: {}", e))?;
+
+    let mut meetings: Vec<MeetingSummary> = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let is_meeting_json = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|n| n.ends_with(".meeting.json"))
+            .unwrap_or(false);
+        if !is_meeting_json {
+            continue;
+        }
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        // We only need id, date, and duration_seconds for matching, so parse
+        // just the fields we need from the meeting.json.
+        let meta: serde_json::Value = match serde_json::from_str(&content) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+
+        let stem = match path.file_stem().and_then(|s| s.to_str()) {
+            Some(s) => s,
+            None => continue,
+        };
+        let id = stem
+            .strip_suffix(".meeting")
+            .unwrap_or(stem)
+            .to_string();
+        let date = meta
+            .get("date")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let duration = meta
+            .get("duration_seconds")
+            .and_then(|v| v.as_f64());
+
+        if date.is_empty() {
+            continue;
+        }
+
+        // We only use id, date, and duration_seconds for matching, so build a
+        // lightweight placeholder. Using a default MeetingSummary avoids
+        // exposing parse_meeting_json as pub.
+        meetings.push(MeetingSummary {
+            id,
+            title: String::new(),
+            date,
+            platform: String::new(),
+            participants: Vec::new(),
+            company: None,
+            duration_seconds: duration,
+            pipeline_status: Default::default(),
+            has_note: false,
+            has_transcript: false,
+            has_video: false,
+            recording_path: None,
+            note_path: None,
+        });
+    }
+
+    // Match events to meetings.
+    let mut matches: HashMap<String, String> = HashMap::new();
+    for event in &cache.events {
+        for meeting in &meetings {
+            if match_event_to_recording(event, &meeting.date, meeting.duration_seconds) {
+                matches.insert(event.id.clone(), meeting.id.clone());
+                break; // one match per event
+            }
+        }
+    }
+
+    Ok(matches)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -83,7 +83,6 @@ pub fn run() {
             calendar::fetch_calendar_events,
             calendar::get_upcoming_meetings,
             calendar::sync_calendar,
-            calendar::get_calendar_matches,
         ])
         .on_window_event(|window, event| {
             // Closing the window hides it instead of quitting

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,11 +1,13 @@
 use tauri::Manager;
 use tauri_plugin_window_state::{AppHandleExt, StateFlags, WindowExt};
 
+mod briefing;
 mod calendar;
 mod credentials;
 mod deep_link;
 mod diagnostics;
 mod meetings;
+mod notifications;
 mod oauth;
 mod recorder;
 mod sidecar;
@@ -47,6 +49,16 @@ pub fn run() {
             // Deep link handler
             deep_link::setup_deep_links(app.handle())?;
 
+            // Start periodic notification check (every 60 seconds)
+            let notification_handle = app.handle().clone();
+            tokio::spawn(async move {
+                let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+                loop {
+                    interval.tick().await;
+                    let _ = notifications::check_upcoming_notifications(&notification_handle);
+                }
+            });
+
             // Show the main window on launch.
             // TODO: When auto-start-with-Windows is implemented, check if launched
             // via startup and hide instead (start in tray).
@@ -84,6 +96,8 @@ pub fn run() {
             calendar::get_upcoming_meetings,
             calendar::sync_calendar,
             calendar::get_calendar_matches,
+            briefing::generate_briefing,
+            briefing::invalidate_briefing_cache,
         ])
         .on_window_event(|window, event| {
             // Closing the window hides it instead of quitting

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 use tauri::Manager;
 use tauri_plugin_window_state::{AppHandleExt, StateFlags, WindowExt};
 
+mod calendar;
 mod credentials;
 mod deep_link;
 mod diagnostics;
@@ -77,6 +78,12 @@ pub fn run() {
             meetings::search_meetings,
             meetings::get_filter_options,
             meetings::get_graph_data,
+            meetings::get_known_participants,
+            meetings::update_speaker_labels,
+            calendar::fetch_calendar_events,
+            calendar::get_upcoming_meetings,
+            calendar::sync_calendar,
+            calendar::get_calendar_matches,
         ])
         .on_window_event(|window, event| {
             // Closing the window hides it instead of quitting

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -83,6 +83,7 @@ pub fn run() {
             calendar::fetch_calendar_events,
             calendar::get_upcoming_meetings,
             calendar::sync_calendar,
+            calendar::get_calendar_matches,
         ])
         .on_window_event(|window, event| {
             // Closing the window hides it instead of quitting

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -95,6 +95,7 @@ pub fn run() {
             calendar::fetch_calendar_events,
             calendar::get_upcoming_meetings,
             calendar::sync_calendar,
+            calendar::get_calendar_last_synced,
             calendar::get_calendar_matches,
             briefing::generate_briefing,
             briefing::invalidate_briefing_cache,

--- a/src-tauri/src/meetings.rs
+++ b/src-tauri/src/meetings.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -662,4 +662,60 @@ pub async fn get_graph_data(
     }
 
     Ok(GraphData { nodes, edges })
+}
+
+#[tauri::command]
+pub async fn get_known_participants(
+    recordings_dir: String,
+) -> Result<Vec<String>, String> {
+    let recordings_path = PathBuf::from(&recordings_dir);
+    if !recordings_path.is_dir() {
+        return Err(format!("Recordings directory does not exist: {}", recordings_dir));
+    }
+
+    let mut participants: BTreeSet<String> = BTreeSet::new();
+
+    let entries = std::fs::read_dir(&recordings_path)
+        .map_err(|e| format!("Failed to read recordings directory: {}", e))?;
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let is_meeting_json = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|n| n.ends_with(".meeting.json"))
+            .unwrap_or(false);
+        if !is_meeting_json {
+            continue;
+        }
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let meta: MeetingJson = match serde_json::from_str(&content) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        for p in &meta.participants {
+            if !p.name.is_empty() {
+                participants.insert(p.name.clone());
+            }
+        }
+    }
+
+    Ok(participants.into_iter().collect())
+}
+
+#[tauri::command]
+pub async fn update_speaker_labels(
+    recording_dir: String,
+    corrections: HashMap<String, String>,
+) -> Result<(), String> {
+    let dir = PathBuf::from(&recording_dir);
+    let labels_path = dir.join("speaker_labels.json");
+    let content = serde_json::to_string_pretty(&corrections)
+        .map_err(|e| format!("Failed to serialize corrections: {}", e))?;
+    std::fs::write(&labels_path, content)
+        .map_err(|e| format!("Failed to write speaker_labels.json: {}", e))?;
+    Ok(())
 }

--- a/src-tauri/src/notifications.rs
+++ b/src-tauri/src/notifications.rs
@@ -118,5 +118,22 @@ pub fn check_upcoming_notifications<R: Runtime>(app: &AppHandle<R>) -> Result<()
         }
     }
 
+    // Prune notified set: remove event IDs whose start time is in the past,
+    // so the set doesn't grow unboundedly across long-running sessions.
+    let current_event_ids: HashSet<&String> = cache.events.iter().map(|e| &e.id).collect();
+    set.retain(|id| {
+        // Keep if the event is still in the cache and hasn't started yet
+        if !current_event_ids.contains(id) {
+            return false;
+        }
+        // Find the event and check if it's still in the future
+        cache.events.iter().any(|e| {
+            e.id == *id
+                && DateTime::parse_from_rfc3339(&e.start)
+                    .map(|dt| dt.with_timezone(&Utc) > now)
+                    .unwrap_or(false)
+        })
+    });
+
     Ok(())
 }

--- a/src-tauri/src/notifications.rs
+++ b/src-tauri/src/notifications.rs
@@ -1,0 +1,122 @@
+use std::collections::HashSet;
+use std::sync::Mutex;
+
+use chrono::{DateTime, Utc};
+use tauri::{AppHandle, Manager, Runtime};
+use tauri_plugin_notification::NotificationExt;
+
+use crate::calendar::{CalendarEvent, CalendarCache};
+
+/// Track which event IDs have already had notifications sent.
+static NOTIFIED_EVENTS: Mutex<Option<HashSet<String>>> = Mutex::new(None);
+
+fn get_notified_set() -> std::sync::MutexGuard<'static, Option<HashSet<String>>> {
+    NOTIFIED_EVENTS.lock().unwrap()
+}
+
+/// Read settings from the Tauri plugin-store to get notification preferences.
+fn read_notification_settings(app: &AppHandle<impl Runtime>) -> (bool, u32) {
+    let store_path = match app.path().app_data_dir() {
+        Ok(dir) => dir.join("settings.json"),
+        Err(_) => return (true, 10),
+    };
+
+    let content = match std::fs::read_to_string(&store_path) {
+        Ok(c) => c,
+        Err(_) => return (true, 10),
+    };
+
+    let store_data: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return (true, 10),
+    };
+
+    let enabled = store_data
+        .get("meetingNotifications")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
+
+    let lead_time = store_data
+        .get("meetingLeadTimeMinutes")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(10) as u32;
+
+    (enabled, lead_time)
+}
+
+/// Read cached calendar events from disk.
+fn read_calendar_cache(app: &AppHandle<impl Runtime>) -> Option<CalendarCache> {
+    let cache_path = app
+        .path()
+        .app_data_dir()
+        .ok()?
+        .join("calendar_cache.json");
+
+    let content = std::fs::read_to_string(&cache_path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+/// Check for upcoming meetings and send desktop notifications.
+///
+/// This should be called periodically (e.g., every minute on a timer or on
+/// app focus) to check if any meetings are starting soon.
+pub fn check_upcoming_notifications<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
+    let (enabled, lead_time_minutes) = read_notification_settings(app);
+
+    if !enabled {
+        return Ok(());
+    }
+
+    let cache = match read_calendar_cache(app) {
+        Some(c) => c,
+        None => return Ok(()), // No calendar data yet
+    };
+
+    let now = Utc::now();
+    let lead_time = chrono::Duration::minutes(lead_time_minutes as i64);
+    let horizon = now + lead_time;
+
+    let mut notified = get_notified_set();
+    let set = notified.get_or_insert_with(HashSet::new);
+
+    for event in &cache.events {
+        // Skip already-notified events
+        if set.contains(&event.id) {
+            continue;
+        }
+
+        let event_start = match DateTime::parse_from_rfc3339(&event.start) {
+            Ok(dt) => dt.with_timezone(&Utc),
+            Err(_) => continue,
+        };
+
+        // Event must be in the future and within the lead time window
+        if event_start > now && event_start <= horizon {
+            let minutes_until = (event_start - now).num_minutes();
+
+            let participants_list: String = event
+                .participants
+                .iter()
+                .map(|p| p.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            let body = if participants_list.is_empty() {
+                format!("In {} min", minutes_until)
+            } else {
+                format!("In {} min — {}", minutes_until, participants_list)
+            };
+
+            let _ = app
+                .notification()
+                .builder()
+                .title(&format!("Upcoming: {}", event.title))
+                .body(&body)
+                .show();
+
+            set.insert(event.id.clone());
+        }
+    }
+
+    Ok(())
+}

--- a/src-tauri/src/notifications.rs
+++ b/src-tauri/src/notifications.rs
@@ -11,7 +11,7 @@ use crate::calendar::{CalendarEvent, CalendarCache};
 static NOTIFIED_EVENTS: Mutex<Option<HashSet<String>>> = Mutex::new(None);
 
 fn get_notified_set() -> std::sync::MutexGuard<'static, Option<HashSet<String>>> {
-    NOTIFIED_EVENTS.lock().unwrap()
+    NOTIFIED_EVENTS.lock().unwrap_or_else(|e| e.into_inner())
 }
 
 /// Read settings from the Tauri plugin-store to get notification preferences.

--- a/src-tauri/src/recorder/types.rs
+++ b/src-tauri/src/recorder/types.rs
@@ -88,6 +88,7 @@ pub struct StageStatus {
     pub completed: bool,
     pub timestamp: Option<String>,
     pub error: Option<String>,
+    pub waiting: Option<String>,
 }
 
 /// Full pipeline status for a recording.
@@ -107,6 +108,7 @@ impl Default for PipelineStatus {
             completed: false,
             timestamp: None,
             error: None,
+            waiting: None,
         };
         Self {
             merge: empty(),

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -43,6 +43,18 @@
   let filterParticipant = $state<string | null>(null);
   let initialized = $state(false);
 
+  // D5: Auto-sync calendar on window focus, debounced to once per 15 min
+  let lastCalendarSync = $state(0);
+
+  function handleWindowFocus() {
+    const now = Date.now();
+    const fifteenMinutes = 15 * 60 * 1000;
+    if (now - lastCalendarSync > fifteenMinutes) {
+      lastCalendarSync = now;
+      syncCalendar().catch(() => {}); // silent background sync
+    }
+  }
+
   onMount(async () => {
     try {
       await loadCredentials();
@@ -124,7 +136,7 @@
   });
 </script>
 
-<svelte:window onkeydown={handleKeydown} />
+<svelte:window onkeydown={handleKeydown} onfocus={handleWindowFocus} />
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="flex flex-col h-screen" style="background: var(--bg);" onwheel={handleWheel}>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -90,11 +90,11 @@
   });
 </script>
 
-<div class="flex flex-col h-screen" style="background: #1D1D1B;">
+<div class="flex flex-col h-screen" style="background: var(--bg);">
   {#if !initialized}
     <div
       class="flex items-center justify-center h-screen"
-      style="font-family: 'DM Sans', sans-serif; color: #585650;"
+      style="font-family: 'DM Sans', sans-serif; color: var(--text-faint);"
     >
       Loading...
     </div>
@@ -105,8 +105,8 @@
       style="
         height: 48px;
         padding: 0 28px;
-        background: #1A1A18;
-        border-bottom: 1px solid #262624;
+        background: var(--bg);
+        border-bottom: 1px solid var(--border);
         font-family: 'DM Sans', sans-serif;
         gap: 24px;
       "
@@ -116,7 +116,7 @@
           font-family: 'Source Serif 4', serif;
           font-size: 18px;
           font-weight: 700;
-          color: #D8D5CE;
+          color: var(--text);
           margin-right: 12px;
         "
       >
@@ -128,8 +128,8 @@
           font-size: 14.5px;
           text-decoration: none;
           padding: 10px 0;
-          border-bottom: 2px solid {currentRoute === 'dashboard' ? '#A8A078' : 'transparent'};
-          color: {currentRoute === 'dashboard' ? '#A8A078' : '#585650'};
+          border-bottom: 2px solid {currentRoute === 'dashboard' ? 'var(--gold)' : 'transparent'};
+          color: {currentRoute === 'dashboard' ? 'var(--gold)' : 'var(--text-faint)'};
         "
       >Meetings</a>
       <a
@@ -138,8 +138,8 @@
           font-size: 14.5px;
           text-decoration: none;
           padding: 10px 0;
-          border-bottom: 2px solid {currentRoute === 'graph' ? '#A8A078' : 'transparent'};
-          color: {currentRoute === 'graph' ? '#A8A078' : '#585650'};
+          border-bottom: 2px solid {currentRoute === 'graph' ? 'var(--gold)' : 'transparent'};
+          color: {currentRoute === 'graph' ? 'var(--gold)' : 'var(--text-faint)'};
         "
       >Graph</a>
       <a
@@ -148,8 +148,8 @@
           font-size: 14.5px;
           text-decoration: none;
           padding: 10px 0;
-          border-bottom: 2px solid {currentRoute === 'settings' ? '#A8A078' : 'transparent'};
-          color: {currentRoute === 'settings' ? '#A8A078' : '#585650'};
+          border-bottom: 2px solid {currentRoute === 'settings' ? 'var(--gold)' : 'transparent'};
+          color: {currentRoute === 'settings' ? 'var(--gold)' : 'var(--text-faint)'};
         "
       >Settings</a>
     </nav>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -4,11 +4,12 @@
   import { listen } from "@tauri-apps/api/event";
   import Settings from "./routes/Settings.svelte";
   import Dashboard from "./routes/Dashboard.svelte";
+  import Calendar from "./routes/Calendar.svelte";
   import GraphView from "./routes/GraphView.svelte";
   import { loadCredentials, credentials, saveTokens } from "./lib/stores/credentials";
   import type { ProviderName } from "./lib/stores/credentials";
   import { loadSettings, settings, saveSetting } from "./lib/stores/settings";
-  import { exchangeOAuthCode } from "./lib/tauri";
+  import { exchangeOAuthCode, syncCalendar } from "./lib/tauri";
 
   function setZoom(level: number) {
     const clamped = Math.round(Math.min(2.0, Math.max(0.5, level)) * 10) / 10;
@@ -169,6 +170,16 @@
         "
       >Meetings</a>
       <a
+        href="#calendar"
+        style="
+          font-size: 14.5px;
+          text-decoration: none;
+          padding: 10px 0;
+          border-bottom: 2px solid {currentRoute === 'calendar' ? 'var(--gold)' : 'transparent'};
+          color: {currentRoute === 'calendar' ? 'var(--gold)' : 'var(--text-faint)'};
+        "
+      >Calendar</a>
+      <a
         href="#graph"
         style="
           font-size: 14.5px;
@@ -194,6 +205,8 @@
     <div class="flex-1 overflow-hidden">
       {#if currentRoute === "settings"}
         <Settings />
+      {:else if currentRoute === "calendar"}
+        <Calendar />
       {:else if currentRoute === "graph"}
         <GraphView />
       {:else}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -7,8 +7,35 @@
   import GraphView from "./routes/GraphView.svelte";
   import { loadCredentials, credentials, saveTokens } from "./lib/stores/credentials";
   import type { ProviderName } from "./lib/stores/credentials";
-  import { loadSettings, settings } from "./lib/stores/settings";
+  import { loadSettings, settings, saveSetting } from "./lib/stores/settings";
   import { exchangeOAuthCode } from "./lib/tauri";
+
+  function setZoom(level: number) {
+    const clamped = Math.round(Math.min(2.0, Math.max(0.5, level)) * 10) / 10;
+    document.documentElement.style.zoom = String(clamped);
+    saveSetting("zoomLevel", clamped);
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (!e.ctrlKey) return;
+    if (e.key === "=" || e.key === "+") {
+      e.preventDefault();
+      setZoom((get(settings).zoomLevel ?? 1.0) + 0.1);
+    } else if (e.key === "-") {
+      e.preventDefault();
+      setZoom((get(settings).zoomLevel ?? 1.0) - 0.1);
+    } else if (e.key === "0") {
+      e.preventDefault();
+      setZoom(1.0);
+    }
+  }
+
+  function handleWheel(e: WheelEvent) {
+    if (!e.ctrlKey) return;
+    e.preventDefault();
+    const current = get(settings).zoomLevel ?? 1.0;
+    setZoom(current + (e.deltaY < 0 ? 0.1 : -0.1));
+  }
 
   let currentRoute = $state("dashboard");
   let meetingId = $state<string | null>(null);
@@ -27,6 +54,12 @@
       console.error("Failed to load settings:", err);
     }
     initialized = true;
+
+    // Apply persisted zoom level
+    const savedZoom = get(settings).zoomLevel;
+    if (savedZoom && savedZoom !== 1.0) {
+      document.documentElement.style.zoom = String(savedZoom);
+    }
 
     const updateRoute = () => {
       const hash = window.location.hash.slice(1) || "dashboard";
@@ -90,7 +123,10 @@
   });
 </script>
 
-<div class="flex flex-col h-screen" style="background: var(--bg);">
+<svelte:window onkeydown={handleKeydown} />
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="flex flex-col h-screen" style="background: var(--bg);" onwheel={handleWheel}>
   {#if !initialized}
     <div
       class="flex items-center justify-center h-screen"

--- a/src/app.css
+++ b/src/app.css
@@ -1,32 +1,35 @@
 @import "tailwindcss";
 
+:root {
+  --bg: #151921;
+  --surface: #1c2128;
+  --raised: #272d35;
+  --border: #363d47;
+  --border-bright: #4a5260;
+  --text: #d4dae3;
+  --text-secondary: #9ba3af;
+  --text-muted: #7a8493;
+  --text-faint: #545d6a;
+  --gold: #C4A84D;
+  --gold-hover: #d4b85d;
+  --gold-muted: #b09840;
+  --blue: #4d9cf5;
+  --green: #4baa55;
+  --red: #ef534a;
+  --warning: #d4a04a;
+}
+
 /* ── Global dark scrollbar ── */
 * {
   scrollbar-width: thin;
-  scrollbar-color: #464440 transparent;
+  scrollbar-color: var(--border) transparent;
 }
 
-::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
-}
-
-::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-::-webkit-scrollbar-thumb {
-  background: #464440;
-  border-radius: 3px;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: #585650;
-}
-
-::-webkit-scrollbar-corner {
-  background: transparent;
-}
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--text-faint); }
+::-webkit-scrollbar-corner { background: transparent; }
 
 /* ── Dark number input spinners ── */
 input[type="number"]::-webkit-inner-spin-button,

--- a/src/lib/components/AboutSection.svelte
+++ b/src/lib/components/AboutSection.svelte
@@ -20,24 +20,24 @@
 
 <div style="display:flex;flex-direction:column;gap:8px;font-size:15px;font-family:'DM Sans',sans-serif;">
   <div style="display:flex;justify-content:space-between;">
-    <span style="color:#78756E;">Version</span>
-    <span style="color:#D8D5CE;">{version}</span>
+    <span style="color:var(--text-muted);">Version</span>
+    <span style="color:var(--text);">{version}</span>
   </div>
   <div style="display:flex;justify-content:space-between;">
-    <span style="color:#78756E;">Pipeline Sidecar</span>
-    <span style="color:{sidecarFound ? '#4ade80' : '#D06850'};">
+    <span style="color:var(--text-muted);">Pipeline Sidecar</span>
+    <span style="color:{sidecarFound ? 'var(--green)' : 'var(--red)'};">
       {sidecarFound === null ? "Checking..." : sidecarFound ? "Found" : "Not found"}
     </span>
   </div>
   <div style="display:flex;justify-content:space-between;">
-    <span style="color:#78756E;">ffmpeg</span>
-    <span style="color:{ffmpegFound ? '#4ade80' : '#D06850'};">
+    <span style="color:var(--text-muted);">ffmpeg</span>
+    <span style="color:{ffmpegFound ? 'var(--green)' : 'var(--red)'};">
       {ffmpegFound === null ? "Checking..." : ffmpegFound ? "Found" : "Not found"}
     </span>
   </div>
   <div style="display:flex;justify-content:space-between;">
-    <span style="color:#78756E;">NVENC (H.265)</span>
-    <span style="color:{nvencStatus === 'Available' ? '#4ade80' : '#f59e0b'};">
+    <span style="color:var(--text-muted);">NVENC (H.265)</span>
+    <span style="color:{nvencStatus === 'Available' ? 'var(--green)' : 'var(--warning)'};">
       {ffmpegFound === false ? "Requires ffmpeg" : nvencStatus ?? "Checking..."}
     </span>
   </div>

--- a/src/lib/components/BriefingPanel.svelte
+++ b/src/lib/components/BriefingPanel.svelte
@@ -1,0 +1,250 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { get } from "svelte/store";
+  import { settings } from "../stores/settings";
+  import { generateBriefing, type Briefing } from "../tauri";
+
+  interface Props {
+    eventId: string;
+    title: string;
+    participants: string[];
+    time: string;
+    eventDescription?: string;
+  }
+
+  let { eventId, title, participants, time, eventDescription }: Props = $props();
+
+  let briefing: Briefing | null = $state(null);
+  let loading = $state(true);
+  let error: string | null = $state(null);
+
+  async function loadBriefing() {
+    loading = true;
+    error = null;
+    try {
+      const s = get(settings);
+      const participantNames = participants;
+      const vaultMeetingsDir = s.vaultPath && s.meetingsFolder
+        ? `${s.vaultPath}/${s.meetingsFolder}`
+        : undefined;
+
+      briefing = await generateBriefing(
+        eventId,
+        title,
+        participantNames,
+        time,
+        s.recordingsFolder,
+        vaultMeetingsDir,
+        eventDescription
+      );
+    } catch (err) {
+      error = String(err);
+      console.error("Briefing generation failed:", err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  onMount(() => {
+    loadBriefing();
+  });
+</script>
+
+<div
+  style="
+    background: var(--bg);
+    border-top: 1px solid var(--border);
+    padding: 16px 18px;
+    font-family: 'DM Sans', sans-serif;
+  "
+>
+  {#if loading}
+    <!-- Loading state -->
+    <div style="display: flex; align-items: center; gap: 10px; padding: 12px 0;">
+      <div
+        style="
+          width: 16px;
+          height: 16px;
+          border: 2px solid var(--border);
+          border-top-color: var(--gold);
+          border-radius: 50%;
+          animation: spin 0.8s linear infinite;
+        "
+      ></div>
+      <span style="font-size: 13px; color: var(--text-muted);">Generating briefing...</span>
+    </div>
+  {:else if error}
+    <!-- Error state -->
+    <div style="padding: 12px 0;">
+      <div style="font-size: 13px; color: var(--red); margin-bottom: 8px;">
+        Failed to generate briefing: {error}
+      </div>
+      <button
+        onclick={loadBriefing}
+        style="
+          padding: 4px 12px;
+          font-size: 12px;
+          font-family: 'DM Sans', sans-serif;
+          border-radius: 4px;
+          border: 1px solid var(--border);
+          background: var(--surface);
+          color: var(--text);
+          cursor: pointer;
+        "
+      >Retry</button>
+    </div>
+  {:else if briefing}
+    <!-- First-meeting banner -->
+    {#if briefing.first_meeting}
+      <div
+        style="
+          background: var(--surface);
+          border: 1px solid var(--gold);
+          border-radius: 6px;
+          padding: 10px 14px;
+          margin-bottom: 14px;
+          font-size: 13px;
+          color: var(--gold);
+        "
+      >
+        First meeting with these participants
+        {#if eventDescription}
+          <div style="color: var(--text-muted); margin-top: 6px; font-size: 12.5px;">
+            {eventDescription}
+          </div>
+        {/if}
+      </div>
+    {/if}
+
+    <!-- Topics -->
+    {#if briefing.topics.length > 0}
+      <div style="margin-bottom: 14px;">
+        <h4
+          style="
+            font-size: 12px;
+            font-weight: 600;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            margin: 0 0 6px 0;
+          "
+        >Topics</h4>
+        <ul style="margin: 0; padding-left: 18px; list-style: none;">
+          {#each briefing.topics as topic}
+            <li
+              style="
+                font-size: 13px;
+                color: var(--text);
+                padding: 2px 0;
+                position: relative;
+                padding-left: 2px;
+              "
+            >
+              <span
+                style="
+                  position: absolute;
+                  left: -14px;
+                  color: var(--gold);
+                  font-weight: bold;
+                "
+              >&bull;</span>
+              {topic}
+            </li>
+          {/each}
+        </ul>
+      </div>
+    {/if}
+
+    <!-- Open Action Items -->
+    {#if briefing.action_items.length > 0}
+      <div style="margin-bottom: 14px;">
+        <h4
+          style="
+            font-size: 12px;
+            font-weight: 600;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            margin: 0 0 6px 0;
+          "
+        >Open Action Items</h4>
+        <div style="display: flex; flex-direction: column; gap: 4px;">
+          {#each briefing.action_items as item}
+            <div
+              style="
+                display: flex;
+                gap: 8px;
+                font-size: 13px;
+                padding: 4px 0;
+                align-items: baseline;
+              "
+            >
+              <span
+                style="
+                  color: var(--blue);
+                  font-weight: 500;
+                  white-space: nowrap;
+                  flex-shrink: 0;
+                "
+              >{item.assignee}</span>
+              <span style="color: var(--text);">{item.description}</span>
+              <span
+                style="
+                  color: var(--text-faint);
+                  font-size: 12px;
+                  white-space: nowrap;
+                  flex-shrink: 0;
+                  margin-left: auto;
+                "
+              >{item.from_meeting}</span>
+            </div>
+          {/each}
+        </div>
+      </div>
+    {/if}
+
+    <!-- Context -->
+    {#if briefing.context}
+      <div style="margin-bottom: 14px;">
+        <h4
+          style="
+            font-size: 12px;
+            font-weight: 600;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            margin: 0 0 6px 0;
+          "
+        >Context</h4>
+        <p style="font-size: 13px; color: var(--text-muted); margin: 0; line-height: 1.5;">
+          {briefing.context}
+        </p>
+      </div>
+    {/if}
+
+    <!-- Relationship Summary -->
+    {#if briefing.relationship_summary}
+      <div>
+        <h4
+          style="
+            font-size: 12px;
+            font-weight: 600;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            margin: 0 0 6px 0;
+          "
+        >Relationship</h4>
+        <p style="font-size: 13px; color: var(--text-muted); margin: 0; line-height: 1.5;">
+          {briefing.relationship_summary}
+        </p>
+      </div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  @keyframes spin {
+    to { transform: rotate(360deg); }
+  }
+</style>

--- a/src/lib/components/DetailPanel.svelte
+++ b/src/lib/components/DetailPanel.svelte
@@ -165,8 +165,8 @@
   .detail-panel {
     height: 100%;
     overflow-y: auto;
-    background: #1D1D1B;
-    border-left: 1px solid #262624;
+    background: var(--bg);
+    border-left: 1px solid var(--border);
     position: relative;
   }
 
@@ -183,15 +183,15 @@
     height: 28px;
     border-radius: 6px;
     border: none;
-    background: #282826;
-    color: #78756E;
+    background: var(--surface);
+    color: var(--text-muted);
     cursor: pointer;
     transition: background 120ms ease, color 120ms ease;
   }
 
   .close-btn:hover {
-    background: #2B2B28;
-    color: #D8D5CE;
+    background: var(--raised);
+    color: var(--text);
   }
 
   .detail-loading {
@@ -199,14 +199,14 @@
     align-items: center;
     justify-content: center;
     height: 100%;
-    color: #585650;
+    color: var(--text-faint);
   }
 
   .detail-error {
     padding: 24px;
     font-family: 'DM Sans', sans-serif;
     font-size: 14.5px;
-    color: #D06850;
+    color: var(--red);
     background: rgba(200,80,60,0.10);
     margin: 16px;
     border-radius: 8px;
@@ -222,7 +222,7 @@
   .detail-tabs {
     display: flex;
     gap: 0;
-    border-bottom: 1px solid #262624;
+    border-bottom: 1px solid var(--border);
     font-family: 'DM Sans', sans-serif;
     font-size: 14.5px;
   }
@@ -235,23 +235,23 @@
     font-family: 'DM Sans', sans-serif;
     font-size: 14.5px;
     font-weight: 400;
-    color: #585650;
+    color: var(--text-faint);
     border-bottom: 2px solid transparent;
     margin-bottom: -1px;
   }
 
   .detail-tab.active {
     font-weight: 600;
-    color: #A8A078;
-    border-bottom-color: #A8A078;
+    color: var(--gold);
+    border-bottom-color: var(--gold);
   }
 
   .spinner {
     display: inline-block;
     width: 24px;
     height: 24px;
-    border: 2px solid #464440;
-    border-top-color: #A8A078;
+    border: 2px solid var(--border);
+    border-top-color: var(--gold);
     border-radius: 50%;
     animation: spin 0.8s linear infinite;
   }

--- a/src/lib/components/DetailPanel.svelte
+++ b/src/lib/components/DetailPanel.svelte
@@ -10,6 +10,7 @@
   import MeetingTranscript from "./MeetingTranscript.svelte";
   import ScreenshotGallery from "./ScreenshotGallery.svelte";
   import PipelineDots from "./PipelineDots.svelte";
+  import SpeakerReview from "./SpeakerReview.svelte";
 
   interface Props {
     meetingId: string;
@@ -79,6 +80,21 @@
   );
 
   let screenshotCount = $derived(detail?.screenshots.length ?? 0);
+
+  let needsSpeakerReview = $derived(
+    detail?.summary.pipeline_status.analyze?.waiting === "speaker_review"
+  );
+
+  let speakerLabels = $derived.by(() => {
+    if (!detail?.transcript) return {};
+    const counts: Record<string, number> = {};
+    for (const u of detail.transcript) {
+      if (u.speaker.startsWith("SPEAKER_")) {
+        counts[u.speaker] = (counts[u.speaker] ?? 0) + 1;
+      }
+    }
+    return counts;
+  });
 </script>
 
 <div class="detail-panel">
@@ -149,6 +165,14 @@
         {#if activeTab === "notes"}
           <MeetingNotes content={detail.note_content} />
         {:else if activeTab === "transcript"}
+          {#if needsSpeakerReview && detail.summary.recording_path && Object.keys(speakerLabels).length > 0}
+            <SpeakerReview
+              speakerLabels={speakerLabels}
+              calendarParticipants={detail.summary.participants}
+              recordingPath={detail.summary.recording_path}
+              onResumed={loadDetail}
+            />
+          {/if}
           <MeetingTranscript
             utterances={detail.transcript}
             onSeek={handleSeek}

--- a/src/lib/components/FilterSidebar.svelte
+++ b/src/lib/components/FilterSidebar.svelte
@@ -33,8 +33,8 @@
     min-width: {expanded ? '200px' : '0px'};
     overflow: hidden;
     transition: width 200ms ease, min-width 200ms ease;
-    background: #1A1A18;
-    border-right: {expanded ? '1px solid #262624' : 'none'};
+    background: var(--bg);
+    border-right: {expanded ? '1px solid var(--border)' : 'none'};
     height: 100%;
     flex-shrink: 0;
   "
@@ -59,7 +59,7 @@
           style="
             font-size: 13.5px;
             font-weight: 600;
-            color: #D8D5CE;
+            color: var(--text);
             letter-spacing: 0.5px;
           "
         >Filters</span>
@@ -73,7 +73,7 @@
               cursor: pointer;
               font-family: 'DM Sans', sans-serif;
               font-size: 14px;
-              color: #A8A078;
+              color: var(--gold);
             "
           >Clear all</button>
         {/if}
@@ -96,12 +96,12 @@
               font-family: 'DM Sans', sans-serif;
               font-size: 12px;
               font-weight: 600;
-              color: #585650;
+              color: var(--text-faint);
               text-transform: uppercase;
               letter-spacing: 0.8px;
             "
           >
-            <span style="font-size: 9px; color: #585650;">
+            <span style="font-size: 9px; color: var(--text-faint);">
               {companiesOpen ? "\u25BC" : "\u25B6"}
             </span>
             Company
@@ -110,7 +110,7 @@
                 style="
                   margin-left: auto;
                   background: rgba(168,160,120,0.15);
-                  color: #A8A078;
+                  color: var(--gold);
                   font-size: 10px;
                   font-weight: 600;
                   padding: 1px 6px;
@@ -130,7 +130,7 @@
                     padding: 3px 0;
                     cursor: pointer;
                     font-size: 14px;
-                    color: #B0ADA5;
+                    color: var(--text-secondary);
                   "
                 >
                   <input
@@ -164,12 +164,12 @@
               font-family: 'DM Sans', sans-serif;
               font-size: 12px;
               font-weight: 600;
-              color: #585650;
+              color: var(--text-faint);
               text-transform: uppercase;
               letter-spacing: 0.8px;
             "
           >
-            <span style="font-size: 9px; color: #585650;">
+            <span style="font-size: 9px; color: var(--text-faint);">
               {platformsOpen ? "\u25BC" : "\u25B6"}
             </span>
             Platform
@@ -178,7 +178,7 @@
                 style="
                   margin-left: auto;
                   background: rgba(168,160,120,0.15);
-                  color: #A8A078;
+                  color: var(--gold);
                   font-size: 10px;
                   font-weight: 600;
                   padding: 1px 6px;
@@ -198,7 +198,7 @@
                     padding: 3px 0;
                     cursor: pointer;
                     font-size: 14px;
-                    color: #B0ADA5;
+                    color: var(--text-secondary);
                   "
                 >
                   <input
@@ -232,12 +232,12 @@
               font-family: 'DM Sans', sans-serif;
               font-size: 12px;
               font-weight: 600;
-              color: #585650;
+              color: var(--text-faint);
               text-transform: uppercase;
               letter-spacing: 0.8px;
             "
           >
-            <span style="font-size: 9px; color: #585650;">
+            <span style="font-size: 9px; color: var(--text-faint);">
               {participantsOpen ? "\u25BC" : "\u25B6"}
             </span>
             Participants
@@ -246,7 +246,7 @@
                 style="
                   margin-left: auto;
                   background: rgba(168,160,120,0.15);
-                  color: #A8A078;
+                  color: var(--gold);
                   font-size: 10px;
                   font-weight: 600;
                   padding: 1px 6px;
@@ -266,7 +266,7 @@
                     padding: 3px 0;
                     cursor: pointer;
                     font-size: 14px;
-                    color: #B0ADA5;
+                    color: var(--text-secondary);
                   "
                 >
                   <input
@@ -288,7 +288,7 @@
         <div
           style="
             font-size: 13.5px;
-            color: #585650;
+            color: var(--text-faint);
             padding: 8px 0;
           "
         >
@@ -305,7 +305,7 @@
     -webkit-appearance: none;
     width: 14px;
     height: 14px;
-    border: 1.5px solid #464440;
+    border: 1.5px solid var(--border);
     border-radius: 3px;
     background: transparent;
     cursor: pointer;
@@ -314,8 +314,8 @@
   }
 
   .filter-checkbox:checked {
-    background: #A8A078;
-    border-color: #A8A078;
+    background: var(--gold);
+    border-color: var(--gold);
   }
 
   .filter-checkbox:checked::after {
@@ -325,7 +325,7 @@
     top: 0px;
     width: 5px;
     height: 8px;
-    border: solid #1A1A18;
+    border: solid var(--bg);
     border-width: 0 2px 2px 0;
     transform: rotate(45deg);
   }

--- a/src/lib/components/GeneralSettings.svelte
+++ b/src/lib/components/GeneralSettings.svelte
@@ -3,13 +3,13 @@
 </script>
 
 <div style="display:flex;flex-direction:column;gap:12px;">
-  <label style="display:flex;align-items:center;gap:8px;font-size:15px;color:#78756E;font-family:'DM Sans',sans-serif;">
-    <input type="checkbox" disabled style="accent-color:#A8A078;" />
+  <label style="display:flex;align-items:center;gap:8px;font-size:15px;color:var(--text-muted);font-family:'DM Sans',sans-serif;">
+    <input type="checkbox" disabled style="accent-color:var(--gold);" />
     Start on login
-    <span style="font-size:12.5px;color:#585650;">(enabled in final release)</span>
+    <span style="font-size:12.5px;color:var(--text-faint);">(enabled in final release)</span>
   </label>
-  <label style="display:flex;align-items:center;gap:8px;font-size:15px;color:#B0ADA5;font-family:'DM Sans',sans-serif;">
-    <input type="checkbox" checked={$settings.showNotificationOnComplete} onchange={(e) => saveSetting("showNotificationOnComplete", e.currentTarget.checked)} style="accent-color:#A8A078;" />
+  <label style="display:flex;align-items:center;gap:8px;font-size:15px;color:var(--text-secondary);font-family:'DM Sans',sans-serif;">
+    <input type="checkbox" checked={$settings.showNotificationOnComplete} onchange={(e) => saveSetting("showNotificationOnComplete", e.currentTarget.checked)} style="accent-color:var(--gold);" />
     Show notification when processing complete
   </label>
 </div>

--- a/src/lib/components/GeneralSettings.svelte
+++ b/src/lib/components/GeneralSettings.svelte
@@ -12,4 +12,30 @@
     <input type="checkbox" checked={$settings.showNotificationOnComplete} onchange={(e) => saveSetting("showNotificationOnComplete", e.currentTarget.checked)} style="accent-color:var(--gold);" />
     Show notification when processing complete
   </label>
+  <label style="display:flex;align-items:center;gap:8px;font-size:15px;color:var(--text-secondary);font-family:'DM Sans',sans-serif;">
+    <input type="checkbox" checked={$settings.meetingNotifications} onchange={(e) => saveSetting("meetingNotifications", e.currentTarget.checked)} style="accent-color:var(--gold);" />
+    Pre-meeting notifications
+  </label>
+  {#if $settings.meetingNotifications}
+    <div style="display:flex;align-items:center;gap:8px;margin-left:28px;">
+      <label style="font-size:14px;color:var(--text-muted);font-family:'DM Sans',sans-serif;">Lead time</label>
+      <select
+        value={$settings.meetingLeadTimeMinutes}
+        onchange={(e) => saveSetting("meetingLeadTimeMinutes", Number(e.currentTarget.value))}
+        style="
+          padding: 4px 8px;
+          font-size: 13px;
+          font-family: 'DM Sans', sans-serif;
+          border-radius: 4px;
+          border: 1px solid var(--border);
+          background: var(--surface);
+          color: var(--text);
+        "
+      >
+        <option value={5}>5 minutes</option>
+        <option value={10}>10 minutes</option>
+        <option value={15}>15 minutes</option>
+      </select>
+    </div>
+  {/if}
 </div>

--- a/src/lib/components/GraphControls.svelte
+++ b/src/lib/components/GraphControls.svelte
@@ -235,20 +235,20 @@
     height: 32px;
     border-radius: 8px;
     border: none;
-    background: #242422;
-    color: #78756E;
+    background: var(--surface);
+    color: var(--text-muted);
     cursor: pointer;
     transition: background 120ms ease, color 120ms ease;
   }
 
   .toggle-btn:hover {
-    background: #2B2B28;
-    color: #D8D5CE;
+    background: var(--raised);
+    color: var(--text);
   }
 
   .graph-controls-panel {
     width: 320px;
-    background: #242422;
+    background: var(--surface);
     border-radius: 10px;
     padding: 8px 0;
     box-shadow: 0 4px 20px rgba(0,0,0,0.4);
@@ -258,7 +258,7 @@
   }
 
   .section {
-    border-bottom: 1px solid #2B2B28;
+    border-bottom: 1px solid var(--raised);
   }
 
   .section:last-child {
@@ -277,13 +277,13 @@
     font-family: 'DM Sans', sans-serif;
     font-size: 12px;
     font-weight: 600;
-    color: #78756E;
+    color: var(--text-muted);
     text-transform: uppercase;
     letter-spacing: 0.6px;
   }
 
   .section-header:hover {
-    color: #B0ADA5;
+    color: var(--text-secondary);
   }
 
   .section-arrow {
@@ -300,15 +300,15 @@
     padding: 6px 10px;
     border-radius: 6px;
     border: none;
-    background: #1D1D1B;
-    color: #D8D5CE;
+    background: var(--bg);
+    color: var(--text);
     font-family: 'DM Sans', sans-serif;
     font-size: 13px;
     outline: none;
   }
 
   .filter-input::placeholder {
-    color: #585650;
+    color: var(--text-faint);
   }
 
   .filter-input:focus {
@@ -332,7 +332,7 @@
 
   .group-label {
     font-size: 13px;
-    color: #B0ADA5;
+    color: var(--text-secondary);
   }
 
   .toggle-row {
@@ -342,7 +342,7 @@
     padding: 3px 0;
     cursor: pointer;
     font-size: 13px;
-    color: #B0ADA5;
+    color: var(--text-secondary);
   }
 
   .ctrl-checkbox {
@@ -350,7 +350,7 @@
     -webkit-appearance: none;
     width: 14px;
     height: 14px;
-    border: 1.5px solid #464440;
+    border: 1.5px solid var(--border);
     border-radius: 3px;
     background: transparent;
     cursor: pointer;
@@ -359,8 +359,8 @@
   }
 
   .ctrl-checkbox:checked {
-    background: #A8A078;
-    border-color: #A8A078;
+    background: var(--gold);
+    border-color: var(--gold);
   }
 
   .ctrl-checkbox:checked::after {
@@ -370,7 +370,7 @@
     top: 0px;
     width: 5px;
     height: 8px;
-    border: solid #1A1A18;
+    border: solid var(--bg);
     border-width: 0 2px 2px 0;
     transform: rotate(45deg);
   }
@@ -384,7 +384,7 @@
 
   .slider-label {
     font-size: 12.5px;
-    color: #78756E;
+    color: var(--text-muted);
     white-space: nowrap;
     min-width: 80px;
   }
@@ -395,7 +395,7 @@
     appearance: none;
     height: 4px;
     border-radius: 2px;
-    background: #1D1D1B;
+    background: var(--bg);
     outline: none;
     cursor: pointer;
   }
@@ -406,13 +406,13 @@
     width: 12px;
     height: 12px;
     border-radius: 50%;
-    background: #A8A078;
+    background: var(--gold);
     cursor: pointer;
   }
 
   .slider-value {
     font-size: 11px;
-    color: #585650;
+    color: var(--text-faint);
     min-width: 28px;
     text-align: right;
     font-variant-numeric: tabular-nums;
@@ -428,7 +428,7 @@
   }
 
   .graph-controls-panel::-webkit-scrollbar-thumb {
-    background: #464440;
+    background: var(--border);
     border-radius: 2px;
   }
 </style>

--- a/src/lib/components/GraphSidebar.svelte
+++ b/src/lib/components/GraphSidebar.svelte
@@ -155,8 +155,8 @@
     right: 0;
     width: 340px;
     height: 100%;
-    background: #1D1D1B;
-    border-left: 1px solid #262624;
+    background: var(--bg);
+    border-left: 1px solid var(--border);
     display: flex;
     flex-direction: column;
     z-index: 20;
@@ -177,7 +177,7 @@
     align-items: center;
     gap: 8px;
     padding: 12px 14px;
-    border-bottom: 1px solid #262624;
+    border-bottom: 1px solid var(--border);
     flex-shrink: 0;
   }
 
@@ -189,16 +189,16 @@
     height: 28px;
     border-radius: 6px;
     border: none;
-    background: #282826;
-    color: #78756E;
+    background: var(--surface);
+    color: var(--text-muted);
     cursor: pointer;
     flex-shrink: 0;
     transition: background 120ms ease, color 120ms ease;
   }
 
   .back-btn:hover {
-    background: #2B2B28;
-    color: #D8D5CE;
+    background: var(--raised);
+    color: var(--text);
   }
 
   .sidebar-title-area {
@@ -210,7 +210,7 @@
     font-family: 'DM Sans', sans-serif;
     font-size: 10px;
     font-weight: 600;
-    color: #585650;
+    color: var(--text-faint);
     text-transform: uppercase;
     letter-spacing: 0.8px;
   }
@@ -219,7 +219,7 @@
     font-family: 'Source Serif 4', serif;
     font-size: 16px;
     font-weight: 600;
-    color: #D8D5CE;
+    color: var(--text);
     margin: 0;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -234,16 +234,16 @@
     height: 28px;
     border-radius: 6px;
     border: none;
-    background: #282826;
-    color: #78756E;
+    background: var(--surface);
+    color: var(--text-muted);
     cursor: pointer;
     flex-shrink: 0;
     transition: background 120ms ease, color 120ms ease;
   }
 
   .close-btn:hover {
-    background: #2B2B28;
-    color: #D8D5CE;
+    background: var(--raised);
+    color: var(--text);
   }
 
   .sidebar-content {
@@ -255,7 +255,7 @@
   .meeting-count {
     font-family: 'DM Sans', sans-serif;
     font-size: 12px;
-    color: #585650;
+    color: var(--text-faint);
     margin-bottom: 8px;
   }
 
@@ -267,7 +267,7 @@
     padding: 10px 12px;
     border-radius: 6px;
     border: none;
-    background: #242422;
+    background: var(--surface);
     cursor: pointer;
     margin-bottom: 4px;
     text-align: left;
@@ -275,7 +275,7 @@
   }
 
   .sidebar-meeting-row:hover {
-    background: #2B2B28;
+    background: var(--raised);
   }
 
   .meeting-dot {
@@ -283,14 +283,14 @@
     width: 8px;
     height: 8px;
     border-radius: 50%;
-    background: #A8A078;
+    background: var(--gold);
     flex-shrink: 0;
   }
 
   .meeting-label {
     font-family: 'DM Sans', sans-serif;
     font-size: 14px;
-    color: #D8D5CE;
+    color: var(--text);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -299,7 +299,7 @@
   .empty-state {
     font-family: 'DM Sans', sans-serif;
     font-size: 14px;
-    color: #585650;
+    color: var(--text-faint);
     text-align: center;
     padding: 24px 0;
   }
@@ -314,7 +314,7 @@
   .error-state {
     font-family: 'DM Sans', sans-serif;
     font-size: 14px;
-    color: #D06850;
+    color: var(--red);
     background: rgba(200,80,60,0.10);
     padding: 12px;
     border-radius: 8px;
@@ -324,26 +324,26 @@
     font-family: 'Source Serif 4', serif;
     font-size: 16px;
     font-weight: 600;
-    color: #D8D5CE;
+    color: var(--text);
     margin: 0 0 4px 0;
   }
 
   .detail-meta {
     font-family: 'DM Sans', sans-serif;
     font-size: 13px;
-    color: #78756E;
+    color: var(--text-muted);
     margin-bottom: 12px;
   }
 
   .meta-dot {
-    color: #464440;
+    color: var(--border);
     margin: 0 4px;
   }
 
   .detail-tabs {
     display: flex;
     gap: 0;
-    border-bottom: 1px solid #262624;
+    border-bottom: 1px solid var(--border);
     margin-bottom: 8px;
   }
 
@@ -355,15 +355,15 @@
     font-family: 'DM Sans', sans-serif;
     font-size: 13px;
     font-weight: 400;
-    color: #585650;
+    color: var(--text-faint);
     border-bottom: 2px solid transparent;
     margin-bottom: -1px;
   }
 
   .detail-tab.active {
     font-weight: 600;
-    color: #A8A078;
-    border-bottom-color: #A8A078;
+    color: var(--gold);
+    border-bottom-color: var(--gold);
   }
 
   .detail-body {
@@ -374,8 +374,8 @@
     display: inline-block;
     width: 20px;
     height: 20px;
-    border: 2px solid #464440;
-    border-top-color: #A8A078;
+    border: 2px solid var(--border);
+    border-top-color: var(--gold);
     border-radius: 50%;
     animation: spin 0.8s linear infinite;
   }
@@ -392,7 +392,7 @@
     background: transparent;
   }
   .sidebar-content::-webkit-scrollbar-thumb {
-    background: #464440;
+    background: var(--border);
     border-radius: 2px;
   }
 </style>

--- a/src/lib/components/MeetingHeader.svelte
+++ b/src/lib/components/MeetingHeader.svelte
@@ -34,13 +34,13 @@
       style="
         font-family: 'DM Sans', sans-serif;
         font-size: 14px;
-        color: #A8A078;
+        color: var(--gold);
         text-decoration: none;
         display: inline-block;
         margin-bottom: 12px;
       "
-      onmouseenter={(e) => { (e.currentTarget as HTMLElement).style.color = '#B8B088'; }}
-      onmouseleave={(e) => { (e.currentTarget as HTMLElement).style.color = '#A8A078'; }}
+      onmouseenter={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--gold-hover)'; }}
+      onmouseleave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--gold)'; }}
     >
       &larr; Back
     </a>
@@ -51,7 +51,7 @@
       font-family: 'Source Serif 4', serif;
       font-size: 24px;
       font-weight: 700;
-      color: #D8D5CE;
+      color: var(--text);
       margin: 0 0 8px 0;
     "
   >
@@ -63,21 +63,21 @@
     style="
       font-family: 'DM Sans', sans-serif;
       font-size: 13.5px;
-      color: #78756E;
+      color: var(--text-muted);
       gap: 0;
     "
   >
     <span>{dateStr}</span>
     {#if meeting.platform}
-      <span style="color: #464440; margin: 0 6px;">&middot;</span>
+      <span style="color: var(--border); margin: 0 6px;">&middot;</span>
       <span>{meeting.platform}</span>
     {/if}
     {#if durationText}
-      <span style="color: #464440; margin: 0 6px;">&middot;</span>
+      <span style="color: var(--border); margin: 0 6px;">&middot;</span>
       <span>{durationText}</span>
     {/if}
     {#if meeting.participants.length}
-      <span style="color: #464440; margin: 0 6px;">&middot;</span>
+      <span style="color: var(--border); margin: 0 6px;">&middot;</span>
       <span>{meeting.participants.join(", ")}</span>
     {/if}
   </div>

--- a/src/lib/components/MeetingList.svelte
+++ b/src/lib/components/MeetingList.svelte
@@ -61,7 +61,7 @@
     class="flex flex-col items-center justify-center py-20"
     style="
       font-family: 'DM Sans', sans-serif;
-      color: #585650;
+      color: var(--text-faint);
       font-size: 15px;
     "
   >
@@ -76,7 +76,7 @@
           font-family: 'DM Sans', sans-serif;
           font-size: 12px;
           font-weight: 600;
-          color: #585650;
+          color: var(--text-faint);
           text-transform: uppercase;
           letter-spacing: 0.05em;
         "
@@ -102,8 +102,8 @@
           padding: 6px 20px;
           border-radius: 6px;
           border: none;
-          background: #242422;
-          color: #A8A078;
+          background: var(--surface);
+          color: var(--gold);
           font-family: 'DM Sans', sans-serif;
           font-size: 14px;
           font-weight: 600;
@@ -112,11 +112,11 @@
         "
         onmouseenter={(e) => {
           const el = e.currentTarget as HTMLElement;
-          el.style.background = '#2B2B28';
+          el.style.background = 'var(--raised)';
         }}
         onmouseleave={(e) => {
           const el = e.currentTarget as HTMLElement;
-          el.style.background = '#242422';
+          el.style.background = 'var(--surface)';
         }}
       >
         {isLoading ? "Loading..." : "Load more"}
@@ -136,8 +136,8 @@
     display: inline-block;
     width: 18px;
     height: 18px;
-    border: 2px solid #464440;
-    border-top-color: #A8A078;
+    border: 2px solid var(--border);
+    border-top-color: var(--gold);
     border-radius: 50%;
     animation: spin 0.8s linear infinite;
   }

--- a/src/lib/components/MeetingNotes.svelte
+++ b/src/lib/components/MeetingNotes.svelte
@@ -14,7 +14,7 @@
   <div class="meeting-notes" style="
     font-family: 'DM Sans', sans-serif;
     font-size: 15px;
-    color: #B0ADA5;
+    color: var(--text-secondary);
     line-height: 1.65;
     padding: 16px 0;
   ">
@@ -26,7 +26,7 @@
     style="
       font-family: 'DM Sans', sans-serif;
       font-size: 15px;
-      color: #585650;
+      color: var(--text-faint);
     "
   >
     No meeting note
@@ -39,7 +39,7 @@
   .meeting-notes :global(h3),
   .meeting-notes :global(h4) {
     font-family: 'Source Serif 4', serif;
-    color: #D8D5CE;
+    color: var(--text);
     margin: 1.2em 0 0.4em;
   }
 
@@ -62,14 +62,14 @@
   }
 
   .meeting-notes :global(code) {
-    background: #282826;
+    background: var(--surface);
     padding: 2px 6px;
     border-radius: 4px;
     font-size: 13.5px;
   }
 
   .meeting-notes :global(pre) {
-    background: #282826;
+    background: var(--surface);
     padding: 12px;
     border-radius: 8px;
     overflow-x: auto;
@@ -77,30 +77,30 @@
   }
 
   .meeting-notes :global(blockquote) {
-    border-left: 3px solid #464440;
+    border-left: 3px solid var(--border);
     margin: 0.5em 0;
     padding-left: 12px;
-    color: #78756E;
+    color: var(--text-muted);
   }
 
   .meeting-notes :global(a) {
-    color: #A8A078;
+    color: var(--gold);
     text-decoration: none;
   }
 
   .meeting-notes :global(a:hover) {
-    color: #B8B088;
+    color: var(--gold-hover);
     text-decoration: underline;
   }
 
   .meeting-notes :global(.wikilink) {
-    color: #A8A078;
+    color: var(--gold);
     text-decoration: none;
     cursor: pointer;
   }
 
   .meeting-notes :global(.wikilink:hover) {
-    color: #B8B088;
+    color: var(--gold-hover);
     text-decoration: underline;
   }
 

--- a/src/lib/components/MeetingPlayer.svelte
+++ b/src/lib/components/MeetingPlayer.svelte
@@ -53,7 +53,7 @@
       width: 100%;
       border-radius: 8px;
       overflow: hidden;
-      background: #1A1A18;
+      background: var(--bg);
     `;
 
     const outlet = document.createElement("media-outlet");
@@ -66,17 +66,17 @@
       align-items: center;
       gap: 8px;
       padding: 8px 12px;
-      background: #1A1A18;
+      background: var(--bg);
       font-family: 'DM Sans', sans-serif;
       font-size: 13.5px;
-      color: #B0ADA5;
+      color: var(--text-secondary);
     `;
 
     // Play/pause button
     const playBtn = document.createElement("button");
     playBtn.textContent = "\u25B6";
     playBtn.style.cssText = `
-      color: #D8D5CE; cursor: pointer; background: none; border: none;
+      color: var(--text); cursor: pointer; background: none; border: none;
       font-size: 18px; padding: 4px 8px;
     `;
     playBtn.addEventListener("click", () => {
@@ -90,7 +90,7 @@
 
     // Time display
     const timeDisplay = document.createElement("span");
-    timeDisplay.style.cssText = "font-size: 12.5px; color: #78756E; min-width: 80px;";
+    timeDisplay.style.cssText = "font-size: 12.5px; color: var(--text-muted); min-width: 80px;";
     timeDisplay.textContent = "0:00 / 0:00";
     controls.appendChild(timeDisplay);
 
@@ -145,11 +145,11 @@
     class="flex items-center justify-center"
     style="
       height: 200px;
-      background: #242422;
+      background: var(--surface);
       border-radius: 8px;
       font-family: 'DM Sans', sans-serif;
       font-size: 14.5px;
-      color: #585650;
+      color: var(--text-faint);
     "
   >
     No recording available

--- a/src/lib/components/MeetingRow.svelte
+++ b/src/lib/components/MeetingRow.svelte
@@ -25,6 +25,10 @@
     return `${meeting.participants[0]} +${meeting.participants.length - 1}`;
   });
 
+  let needsSpeakerReview = $derived(
+    meeting.pipeline_status.analyze?.waiting === "speaker_review"
+  );
+
   function handleClick(e: MouseEvent) {
     if (onSelect) {
       e.preventDefault();
@@ -100,6 +104,22 @@
         {/if}
       </div>
     </div>
-    <PipelineDots status={meeting.pipeline_status} recordingPath={meeting.recording_path} />
+    <div class="flex items-center gap-2">
+      {#if needsSpeakerReview}
+        <span
+          style="
+            font-family: 'DM Sans', sans-serif;
+            font-size: 11px;
+            font-weight: 600;
+            color: var(--gold);
+            background: rgba(196, 168, 77, 0.12);
+            padding: 2px 8px;
+            border-radius: 4px;
+            white-space: nowrap;
+          "
+        >Review Speakers</span>
+      {/if}
+      <PipelineDots status={meeting.pipeline_status} recordingPath={meeting.recording_path} />
+    </div>
   </div>
 </a>

--- a/src/lib/components/MeetingRow.svelte
+++ b/src/lib/components/MeetingRow.svelte
@@ -40,25 +40,25 @@
   style="
     padding: 14px 16px;
     border-radius: 8px;
-    background: {isSelected ? '#2B2B28' : '#242422'};
+    background: {isSelected ? 'var(--raised)' : 'var(--surface)'};
     text-decoration: none;
     transition: background 120ms ease, box-shadow 120ms ease;
-    {isSelected ? 'box-shadow: inset 2px 0 0 #A8A078;' : ''}
+    {isSelected ? 'box-shadow: inset 2px 0 0 var(--gold);' : ''}
   "
   onmouseenter={(e) => {
     if (!isSelected) {
       const el = e.currentTarget as HTMLElement;
-      el.style.background = '#2B2B28';
+      el.style.background = 'var(--raised)';
       el.style.boxShadow = '0 1px 8px rgba(0,0,0,0.25)';
     }
   }}
   onmouseleave={(e) => {
     const el = e.currentTarget as HTMLElement;
     if (isSelected) {
-      el.style.background = '#2B2B28';
-      el.style.boxShadow = 'inset 2px 0 0 #A8A078';
+      el.style.background = 'var(--raised)';
+      el.style.boxShadow = 'inset 2px 0 0 var(--gold)';
     } else {
-      el.style.background = '#242422';
+      el.style.background = 'var(--surface)';
       el.style.boxShadow = 'none';
     }
   }}
@@ -70,7 +70,7 @@
           font-family: 'Source Serif 4', serif;
           font-size: 16px;
           font-weight: 600;
-          color: #D8D5CE;
+          color: var(--text);
           margin: 0 0 4px 0;
           overflow: hidden;
           text-overflow: ellipsis;
@@ -84,18 +84,18 @@
         style="
           font-family: 'DM Sans', sans-serif;
           font-size: 13.5px;
-          color: #78756E;
+          color: var(--text-muted);
         "
       >
         {#if meeting.platform}
           <span>{meeting.platform}</span>
         {/if}
         {#if durationText}
-          <span style="color: #464440; margin: 0 6px;">&middot;</span>
+          <span style="color: var(--border); margin: 0 6px;">&middot;</span>
           <span>{durationText}</span>
         {/if}
         {#if participantText}
-          <span style="color: #464440; margin: 0 6px;">&middot;</span>
+          <span style="color: var(--border); margin: 0 6px;">&middot;</span>
           <span>{participantText}</span>
         {/if}
       </div>

--- a/src/lib/components/MeetingTranscript.svelte
+++ b/src/lib/components/MeetingTranscript.svelte
@@ -9,8 +9,8 @@
   let { utterances, onSeek }: Props = $props();
 
   const speakerColors = [
-    "#A8A078", "#7EA8A0", "#A07EA8", "#A8907E",
-    "#7E90A8", "#A87E8C", "#8CA87E", "#A8A87E",
+    "#C4A84D", "#5e9e96", "#8e6e9e", "#9e826e",
+    "#6e829e", "#9e6e7e", "#7e9e6e", "#9e9e6e",
   ];
 
   function getSpeakerColor(speaker: string, allSpeakers: string[]): string {
@@ -53,7 +53,7 @@
             cursor: pointer;
             font-family: 'DM Sans', sans-serif;
             font-size: 12.5px;
-            color: #585650;
+            color: var(--text-faint);
             min-width: 42px;
             text-align: right;
             line-height: 1.5;
@@ -72,7 +72,7 @@
           >
             {u.speaker}
           </span>
-          <span style="color: #B0ADA5; line-height: 1.5;">
+          <span style="color: var(--text-secondary); line-height: 1.5;">
             {u.text}
           </span>
         </div>
@@ -85,7 +85,7 @@
     style="
       font-family: 'DM Sans', sans-serif;
       font-size: 15px;
-      color: #585650;
+      color: var(--text-faint);
     "
   >
     No transcript available
@@ -94,10 +94,10 @@
 
 <style>
   .utterance-row:hover {
-    background: #2B2B28;
+    background: var(--raised);
   }
 
   .utterance-row button:hover {
-    color: #A8A078 !important;
+    color: var(--gold) !important;
   }
 </style>

--- a/src/lib/components/MeetingTranscript.svelte
+++ b/src/lib/components/MeetingTranscript.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { Utterance } from "../tauri";
+  import { SPEAKER_COLORS } from "../theme";
 
   interface Props {
     utterances: Utterance[] | null;
@@ -8,14 +9,9 @@
 
   let { utterances, onSeek }: Props = $props();
 
-  const speakerColors = [
-    "#C4A84D", "#5e9e96", "#8e6e9e", "#9e826e",
-    "#6e829e", "#9e6e7e", "#7e9e6e", "#9e9e6e",
-  ];
-
   function getSpeakerColor(speaker: string, allSpeakers: string[]): string {
     const idx = allSpeakers.indexOf(speaker);
-    return speakerColors[idx >= 0 ? idx % speakerColors.length : 0];
+    return SPEAKER_COLORS[idx >= 0 ? idx % SPEAKER_COLORS.length : 0];
   }
 
   function formatTime(seconds: number): string {

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -18,7 +18,7 @@
   }
 </script>
 
-<svelte:window on:keydown={onKeydown} />
+<svelte:window onkeydown={onKeydown} />
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -29,17 +29,17 @@
 >
   <div
     class="modal-card"
-    style="background:#242422;border-radius:12px;max-width:480px;width:90%;max-height:85vh;overflow-y:auto;padding:24px;position:relative;box-shadow:0 4px 24px rgba(0,0,0,0.5);"
+    style="background:var(--surface);border-radius:12px;max-width:480px;width:90%;max-height:85vh;overflow-y:auto;padding:24px;position:relative;box-shadow:0 4px 24px rgba(0,0,0,0.5);"
   >
     <button
       onclick={onclose}
-      style="position:absolute;top:12px;right:12px;background:none;border:none;color:#78756E;font-size:20px;cursor:pointer;padding:4px 8px;line-height:1;"
+      style="position:absolute;top:12px;right:12px;background:none;border:none;color:var(--text-muted);font-size:20px;cursor:pointer;padding:4px 8px;line-height:1;"
       aria-label="Close"
     >
       &times;
     </button>
 
-    <h2 style="font-family:'Source Serif 4',serif;font-size:18px;font-weight:600;color:#D8D5CE;margin:0 0 16px 0;">
+    <h2 style="font-family:'Source Serif 4',serif;font-size:18px;font-weight:600;color:var(--text);margin:0 0 16px 0;">
       {title}
     </h2>
 

--- a/src/lib/components/PipelineDots.svelte
+++ b/src/lib/components/PipelineDots.svelte
@@ -23,6 +23,7 @@
   let ariaLabel = $derived.by(() => {
     const parts = stages.map((s) => {
       const st = status[s];
+      if (st.waiting) return `${s}: awaiting review`;
       if (st.error) return `${s}: failed`;
       if (st.completed) return `${s}: completed`;
       return `${s}: pending`;
@@ -32,13 +33,19 @@
 
   function dotColor(stage: Stage): string {
     const st = status[stage];
+    if (st.waiting) return "#D4A843";
     if (st.error) return "#ef534a";
     if (st.completed) return "#C4A84D";
     return "#363d47";
   }
 
+  function isDotPulsing(stage: Stage): boolean {
+    return !!status[stage].waiting;
+  }
+
   function stageIcon(stage: Stage): string {
     const st = status[stage];
+    if (st.waiting) return "\u25CB";
     if (st.error) return "\u2717";
     if (st.completed) return "\u2713";
     return "\u2022";
@@ -46,6 +53,7 @@
 
   function stageIconColor(stage: Stage): string {
     const st = status[stage];
+    if (st.waiting) return "#D4A843";
     if (st.error) return "#ef534a";
     if (st.completed) return "#C4A84D";
     return "#545d6a";
@@ -74,6 +82,7 @@
 
   function dotTitle(stage: Stage): string {
     const s = status[stage];
+    if (s.waiting) return `${stage}: ${s.waiting}`;
     if (s.error) return `${stage}: ${s.error}`;
     if (s.completed) return `${stage}: done`;
     return `${stage}: pending`;
@@ -121,6 +130,7 @@
     {#each stages as stage}
       <span
         title={dotTitle(stage)}
+        class={isDotPulsing(stage) ? 'pulse' : ''}
         style="
           display: inline-block;
           width: 6px;
@@ -178,7 +188,11 @@
                 </span>
               {/if}
             </div>
-            {#if st.error}
+            {#if st.waiting}
+              <div style="color: #D4A843; font-size: 11px; margin-top: 2px; word-break: break-word;">
+                {st.waiting}
+              </div>
+            {:else if st.error}
               <div style="color: var(--red); font-size: 11px; margin-top: 2px; word-break: break-word;">
                 {st.error}
               </div>
@@ -216,3 +230,13 @@
     </div>
   {/if}
 </div>
+
+<style>
+  @keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.4; }
+  }
+  :global(.pulse) {
+    animation: pulse 1.5s ease-in-out infinite;
+  }
+</style>

--- a/src/lib/components/PipelineDots.svelte
+++ b/src/lib/components/PipelineDots.svelte
@@ -34,7 +34,7 @@
     const st = status[stage];
     if (st.error) return "#ef534a";
     if (st.completed) return "#C4A84D";
-    return "#464440";
+    return "#363d47";
   }
 
   function stageIcon(stage: Stage): string {
@@ -48,7 +48,7 @@
     const st = status[stage];
     if (st.error) return "#ef534a";
     if (st.completed) return "#C4A84D";
-    return "#585650";
+    return "#545d6a";
   }
 
   function formatTimestamp(ts: string | null): string | null {

--- a/src/lib/components/PipelineDots.svelte
+++ b/src/lib/components/PipelineDots.svelte
@@ -32,8 +32,8 @@
 
   function dotColor(stage: Stage): string {
     const st = status[stage];
-    if (st.error) return "#D06850";
-    if (st.completed) return "#A8A078";
+    if (st.error) return "#ef534a";
+    if (st.completed) return "#C4A84D";
     return "#464440";
   }
 
@@ -46,8 +46,8 @@
 
   function stageIconColor(stage: Stage): string {
     const st = status[stage];
-    if (st.error) return "#D06850";
-    if (st.completed) return "#A8A078";
+    if (st.error) return "#ef534a";
+    if (st.completed) return "#C4A84D";
     return "#585650";
   }
 
@@ -141,7 +141,7 @@
         margin-top: 8px;
         padding: 10px 12px;
         border-radius: 6px;
-        background: #1A1A18;
+        background: var(--bg);
         font-family: 'DM Sans', sans-serif;
         font-size: 12px;
         min-width: 240px;
@@ -171,15 +171,15 @@
 
           <div style="flex: 1; min-width: 0;">
             <div style="display: flex; align-items: center; justify-content: space-between; gap: 8px;">
-              <span style="color: #D8D5CE; text-transform: capitalize;">{stage}</span>
+              <span style="color: var(--text); text-transform: capitalize;">{stage}</span>
               {#if st.completed && st.timestamp}
-                <span style="color: #78756E; font-size: 11px; white-space: nowrap;">
+                <span style="color: var(--text-muted); font-size: 11px; white-space: nowrap;">
                   {formatTimestamp(st.timestamp)}
                 </span>
               {/if}
             </div>
             {#if st.error}
-              <div style="color: #D06850; font-size: 11px; margin-top: 2px; word-break: break-word;">
+              <div style="color: var(--red); font-size: 11px; margin-top: 2px; word-break: break-word;">
                 {st.error}
               </div>
               {#if recordingPath}
@@ -193,7 +193,7 @@
                     border: 1px solid rgba(208,104,80,0.3);
                     border-radius: 3px;
                     background: rgba(208,104,80,0.08);
-                    color: #D06850;
+                    color: var(--red);
                     font-family: 'DM Sans', sans-serif;
                     font-size: 11px;
                     cursor: pointer;

--- a/src/lib/components/PipelineDots.svelte
+++ b/src/lib/components/PipelineDots.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { PipelineStatus } from "../tauri";
-  import { retryProcessing } from "../tauri";
+  import { retryProcessing, getRecordingDir } from "../tauri";
 
   interface Props {
     status: PipelineStatus;
@@ -15,11 +15,6 @@
   let expanded = $state(false);
   let retrying = $state<string | null>(null);
 
-  function getRecordingDir(filePath: string): string {
-    const lastSep = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
-    return lastSep > 0 ? filePath.substring(0, lastSep) : filePath;
-  }
-
   let ariaLabel = $derived.by(() => {
     const parts = stages.map((s) => {
       const st = status[s];
@@ -33,10 +28,10 @@
 
   function dotColor(stage: Stage): string {
     const st = status[stage];
-    if (st.waiting) return "#D4A843";
-    if (st.error) return "#ef534a";
-    if (st.completed) return "#C4A84D";
-    return "#363d47";
+    if (st.waiting) return "var(--warning)";
+    if (st.error) return "var(--red)";
+    if (st.completed) return "var(--gold)";
+    return "var(--border)";
   }
 
   function isDotPulsing(stage: Stage): boolean {
@@ -53,10 +48,10 @@
 
   function stageIconColor(stage: Stage): string {
     const st = status[stage];
-    if (st.waiting) return "#D4A843";
-    if (st.error) return "#ef534a";
-    if (st.completed) return "#C4A84D";
-    return "#545d6a";
+    if (st.waiting) return "var(--warning)";
+    if (st.error) return "var(--red)";
+    if (st.completed) return "var(--gold)";
+    return "var(--text-faint)";
   }
 
   function formatTimestamp(ts: string | null): string | null {
@@ -189,7 +184,7 @@
               {/if}
             </div>
             {#if st.waiting}
-              <div style="color: #D4A843; font-size: 11px; margin-top: 2px; word-break: break-word;">
+              <div style="color: var(--warning); font-size: 11px; margin-top: 2px; word-break: break-word;">
                 {st.waiting}
               </div>
             {:else if st.error}

--- a/src/lib/components/PipelineStatusBadge.svelte
+++ b/src/lib/components/PipelineStatusBadge.svelte
@@ -43,7 +43,7 @@
     font-weight: 600;
     line-height: 1.4;
     background: {variant === 'done' ? 'rgba(160,150,120,0.12)' : variant === 'active' ? 'rgba(180,165,130,0.10)' : 'rgba(200,80,60,0.10)'};
-    color: {variant === 'done' ? '#A8A078' : variant === 'active' ? '#B4A882' : '#D06850'};
+    color: {variant === 'done' ? 'var(--gold)' : variant === 'active' ? 'var(--gold-muted)' : 'var(--red)'};
   "
 >
   {label}

--- a/src/lib/components/ProviderCard.svelte
+++ b/src/lib/components/ProviderCard.svelte
@@ -64,8 +64,8 @@
     await disconnect(provider);
   }
 
-  const inputStyle = "width:100%;background:#282826;border:1px solid #262624;border-radius:6px;padding:6px 12px;font-size:15px;color:#D8D5CE;font-family:'DM Sans',sans-serif;outline:none;";
-  const labelStyle = "display:block;font-size:14px;color:#78756E;margin-bottom:4px;font-family:'DM Sans',sans-serif;";
+  const inputStyle = "width:100%;background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:6px 12px;font-size:15px;color:var(--text);font-family:'DM Sans',sans-serif;outline:none;";
+  const labelStyle = "display:block;font-size:14px;color:var(--text-muted);margin-bottom:4px;font-family:'DM Sans',sans-serif;";
 </script>
 
 <div style="display:flex;flex-direction:column;gap:12px;">
@@ -112,11 +112,11 @@
   <div style="display:flex;align-items:center;justify-content:space-between;padding-top:8px;">
     <div style="font-size:14.5px;">
       {#if providerState.status === "connected"}
-        <span style="color:#4ade80;">Connected{providerState.displayName ? ` as ${providerState.displayName}` : ""}</span>
+        <span style="color:var(--green);">Connected{providerState.displayName ? ` as ${providerState.displayName}` : ""}</span>
       {:else if providerState.status === "reconnect_required"}
-        <span style="color:#f59e0b;">Reconnect required</span>
+        <span style="color:var(--warning);">Reconnect required</span>
       {:else}
-        <span style="color:#78756E;">Disconnected</span>
+        <span style="color:var(--text-muted);">Disconnected</span>
       {/if}
     </div>
 
@@ -124,7 +124,7 @@
       {#if providerState.status === "connected"}
         <button
           onclick={handleDisconnect}
-          style="font-size:14.5px;color:#D06850;background:none;border:none;cursor:pointer;font-family:'DM Sans',sans-serif;"
+          style="font-size:14.5px;color:var(--red);background:none;border:none;cursor:pointer;font-family:'DM Sans',sans-serif;"
           onmouseenter={(e) => { e.currentTarget.style.textDecoration = 'underline'; }}
           onmouseleave={(e) => { e.currentTarget.style.textDecoration = 'none'; }}
         >
@@ -134,7 +134,7 @@
         <button
           onclick={connect}
           disabled={!hasCredentials || connecting}
-          style="font-size:14.5px;background:#A8A078;color:#1D1D1B;padding:6px 16px;border-radius:6px;border:none;cursor:pointer;font-family:'DM Sans',sans-serif;font-weight:500;opacity:{!hasCredentials || connecting ? '0.5' : '1'};"
+          style="font-size:14.5px;background:var(--gold);color:var(--bg);padding:6px 16px;border-radius:6px;border:none;cursor:pointer;font-family:'DM Sans',sans-serif;font-weight:500;opacity:{!hasCredentials || connecting ? '0.5' : '1'};"
         >
           {connecting ? "Connecting..." : "Connect"}
         </button>
@@ -143,7 +143,7 @@
   </div>
 
   {#if provider === "microsoft" && providerState.status === "connected"}
-    <p style="font-size:13.5px;color:#f59e0b;margin-top:4px;">
+    <p style="font-size:13.5px;color:var(--warning);margin-top:4px;">
       Note: Personal accounts have limited recording API access. Recording will require manual start.
     </p>
   {/if}

--- a/src/lib/components/ProviderStatusCard.svelte
+++ b/src/lib/components/ProviderStatusCard.svelte
@@ -14,10 +14,10 @@
 </script>
 
 <div
-  style="display:flex;align-items:center;justify-content:space-between;padding:12px 16px;background:#242422;border-radius:8px;"
+  style="display:flex;align-items:center;justify-content:space-between;padding:12px 16px;background:var(--surface);border-radius:8px;"
 >
   <div style="display:flex;align-items:center;gap:10px;">
-    <span style="font-family:'DM Sans',sans-serif;font-size:15.5px;font-weight:500;color:#D8D5CE;">
+    <span style="font-family:'DM Sans',sans-serif;font-size:15.5px;font-weight:500;color:var(--text);">
       {label}
     </span>
   </div>
@@ -25,22 +25,22 @@
   <div style="display:flex;align-items:center;gap:12px;">
     <div style="display:flex;align-items:center;gap:6px;">
       {#if isConnected}
-        <span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:#4ade80;"></span>
-        <span style="font-size:14px;color:#B0ADA5;">
+        <span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:var(--green);"></span>
+        <span style="font-size:14px;color:var(--text-secondary);">
           Connected{providerState.displayName ? ` as ${providerState.displayName}` : ""}
         </span>
       {:else if needsReconnect}
-        <span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:#f59e0b;"></span>
-        <span style="font-size:14px;color:#f59e0b;">Reconnect required</span>
+        <span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:var(--warning);"></span>
+        <span style="font-size:14px;color:var(--warning);">Reconnect required</span>
       {:else}
-        <span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:#585650;"></span>
-        <span style="font-size:14px;color:#78756E;">Not connected</span>
+        <span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:var(--text-faint);"></span>
+        <span style="font-size:14px;color:var(--text-muted);">Not connected</span>
       {/if}
     </div>
 
     <button
       onclick={onconfigure}
-      style="font-family:'DM Sans',sans-serif;font-size:14px;color:#A8A078;background:none;border:1px solid #A8A078;border-radius:6px;padding:4px 12px;cursor:pointer;"
+      style="font-family:'DM Sans',sans-serif;font-size:14px;color:var(--gold);background:none;border:1px solid var(--gold);border-radius:6px;padding:4px 12px;cursor:pointer;"
       onmouseenter={(e) => { e.currentTarget.style.background = 'rgba(168,160,120,0.1)'; }}
       onmouseleave={(e) => { e.currentTarget.style.background = 'none'; }}
     >

--- a/src/lib/components/RecordingBehaviorSettings.svelte
+++ b/src/lib/components/RecordingBehaviorSettings.svelte
@@ -1,19 +1,19 @@
 <script lang="ts">
   import { settings, saveSetting } from "../stores/settings";
 
-  const inputStyle = "width:100%;background:#282826;border:1px solid #262624;border-radius:6px;padding:6px 12px;font-size:15px;color:#D8D5CE;font-family:'DM Sans',sans-serif;outline:none;";
-  const labelStyle = "display:block;font-size:14px;color:#78756E;margin-bottom:4px;font-family:'DM Sans',sans-serif;";
+  const inputStyle = "width:100%;background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:6px 12px;font-size:15px;color:var(--text);font-family:'DM Sans',sans-serif;outline:none;";
+  const labelStyle = "display:block;font-size:14px;color:var(--text-muted);margin-bottom:4px;font-family:'DM Sans',sans-serif;";
 </script>
 
 <div style="display:flex;flex-direction:column;gap:12px;">
   <!-- Auto-detect toggle -->
   <label style="display:flex;align-items:center;justify-content:space-between;">
-    <span style="font-size:15px;color:#B0ADA5;font-family:'DM Sans',sans-serif;">Auto-detect Zoom meetings</span>
+    <span style="font-size:15px;color:var(--text-secondary);font-family:'DM Sans',sans-serif;">Auto-detect Zoom meetings</span>
     <input
       type="checkbox"
       checked={$settings.autoDetectMeetings}
       onchange={(e) => saveSetting("autoDetectMeetings", e.currentTarget.checked)}
-      style="accent-color:#A8A078;"
+      style="accent-color:var(--gold);"
     />
   </label>
 

--- a/src/lib/components/RecordingSettings.svelte
+++ b/src/lib/components/RecordingSettings.svelte
@@ -13,20 +13,20 @@
 </script>
 
 <label style="display:block;">
-  <span style="display:block;font-size:14px;color:#78756E;margin-bottom:4px;font-family:'DM Sans',sans-serif;">Recordings Folder</span>
+  <span style="display:block;font-size:14px;color:var(--text-muted);margin-bottom:4px;font-family:'DM Sans',sans-serif;">Recordings Folder</span>
   <div style="display:flex;gap:8px;">
     <input
       type="text"
       value={$settings.recordingsFolder}
       onblur={async (e) => { const newValue = e.currentTarget.value; if (newValue !== $settings.recordingsFolder) { await saveSetting("recordingsFolder", newValue); await resetMeetings(); } }}
-      style="flex:1;background:#282826;border:1px solid #262624;border-radius:6px;padding:6px 12px;font-size:15px;color:#D8D5CE;font-family:'DM Sans',sans-serif;outline:none;"
+      style="flex:1;background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:6px 12px;font-size:15px;color:var(--text);font-family:'DM Sans',sans-serif;outline:none;"
       placeholder="Path to store recordings"
     />
     <button
       onclick={browseRecordingsFolder}
-      style="font-size:14.5px;background:#282826;border:1px solid #262624;border-radius:6px;padding:6px 12px;color:#B0ADA5;cursor:pointer;font-family:'DM Sans',sans-serif;"
-      onmouseenter={(e) => { e.currentTarget.style.background = '#2B2B28'; }}
-      onmouseleave={(e) => { e.currentTarget.style.background = '#282826'; }}
+      style="font-size:14.5px;background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:6px 12px;color:var(--text-secondary);cursor:pointer;font-family:'DM Sans',sans-serif;"
+      onmouseenter={(e) => { e.currentTarget.style.background = 'var(--raised)'; }}
+      onmouseleave={(e) => { e.currentTarget.style.background = 'var(--surface)'; }}
     >
       Browse
     </button>

--- a/src/lib/components/RecordingStatusBar.svelte
+++ b/src/lib/components/RecordingStatusBar.svelte
@@ -13,8 +13,8 @@
     class="flex items-center justify-between"
     style="
       padding: 8px 28px;
-      background: #1A1A18;
-      border-bottom: 1px solid #262624;
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
       font-family: 'DM Sans', sans-serif;
       font-size: 15px;
     "
@@ -22,18 +22,18 @@
     <div class="flex items-center gap-3">
       {#if tag === "recording"}
         <span class="rec-dot"></span>
-        <span style="color: #B0ADA5;">Recording</span>
+        <span style="color: var(--text-secondary);">Recording</span>
       {:else if tag === "detected"}
-        <span style="color: #78756E;">
+        <span style="color: var(--text-muted);">
           <svg class="inline-block mr-1" width="14" height="14" viewBox="0 0 14 14" fill="none">
-            <circle cx="7" cy="7" r="5" stroke="#78756E" stroke-width="1.5"/>
-            <circle cx="7" cy="7" r="2" fill="#78756E"/>
+            <circle cx="7" cy="7" r="5" stroke="var(--text-muted)" stroke-width="1.5"/>
+            <circle cx="7" cy="7" r="2" fill="var(--text-muted)"/>
           </svg>
           {processName} detected
         </span>
       {:else if tag === "processing"}
         <span class="spinner"></span>
-        <span style="color: #B0ADA5;">Processing recording...</span>
+        <span style="color: var(--text-secondary);">Processing recording...</span>
       {/if}
     </div>
 
@@ -45,8 +45,8 @@
             padding: 4px 14px;
             border-radius: 6px;
             border: none;
-            background: #A8A078;
-            color: #1D1D1B;
+            background: var(--gold);
+            color: var(--bg);
             font-family: 'DM Sans', sans-serif;
             font-size: 13.5px;
             font-weight: 600;
@@ -62,8 +62,8 @@
             padding: 4px 14px;
             border-radius: 6px;
             border: none;
-            background: #A8A078;
-            color: #1D1D1B;
+            background: var(--gold);
+            color: var(--bg);
             font-family: 'DM Sans', sans-serif;
             font-size: 13.5px;
             font-weight: 600;
@@ -83,7 +83,7 @@
     width: 8px;
     height: 8px;
     border-radius: 50%;
-    background: #ef4444;
+    background: var(--red);
     animation: pulse 1.5s ease-in-out infinite;
   }
 
@@ -96,8 +96,8 @@
     display: inline-block;
     width: 14px;
     height: 14px;
-    border: 2px solid #464440;
-    border-top-color: #A8A078;
+    border: 2px solid var(--border);
+    border-top-color: var(--gold);
     border-radius: 50%;
     animation: spin 0.8s linear infinite;
   }

--- a/src/lib/components/RetryBanner.svelte
+++ b/src/lib/components/RetryBanner.svelte
@@ -53,7 +53,7 @@
       font-size: 14.5px;
     "
   >
-    <span style="color: {failedStage ? '#D06850' : '#B4A882'};">
+    <span style="color: {failedStage ? 'var(--red)' : 'var(--gold-muted)'};">
       {#if failedStage}
         Pipeline failed at {failedStage}: {meeting.pipeline_status[failedStage].error}
       {:else}
@@ -71,7 +71,7 @@
             border-radius: 6px;
             border: none;
             background: rgba(200,80,60,0.15);
-            color: #D06850;
+            color: var(--red);
             font-family: 'DM Sans', sans-serif;
             font-size: 13.5px;
             font-weight: 600;
@@ -90,7 +90,7 @@
             border-radius: 6px;
             border: none;
             background: rgba(180,165,130,0.15);
-            color: #B4A882;
+            color: var(--gold-muted);
             font-family: 'DM Sans', sans-serif;
             font-size: 13.5px;
             font-weight: 600;
@@ -109,7 +109,7 @@
             border-radius: 6px;
             border: none;
             background: rgba(180,165,130,0.15);
-            color: #B4A882;
+            color: var(--gold-muted);
             font-family: 'DM Sans', sans-serif;
             font-size: 13.5px;
             font-weight: 600;

--- a/src/lib/components/ScreenshotGallery.svelte
+++ b/src/lib/components/ScreenshotGallery.svelte
@@ -19,7 +19,7 @@
         class="overflow-hidden"
         style="
           border-radius: 8px;
-          background: #242422;
+          background: var(--surface);
         "
       >
         <img
@@ -38,7 +38,7 @@
               padding: 8px 10px;
               font-family: 'DM Sans', sans-serif;
               font-size: 13.5px;
-              color: #78756E;
+              color: var(--text-muted);
               line-height: 1.4;
             "
           >
@@ -54,7 +54,7 @@
     style="
       font-family: 'DM Sans', sans-serif;
       font-size: 15px;
-      color: #585650;
+      color: var(--text-faint);
     "
   >
     No screenshots

--- a/src/lib/components/SearchBar.svelte
+++ b/src/lib/components/SearchBar.svelte
@@ -29,8 +29,8 @@
       border-radius: 8px;
       border: none;
       outline: none;
-      background: #282826;
-      color: #B0ADA5;
+      background: var(--surface);
+      color: var(--text-secondary);
       font-family: 'DM Sans', sans-serif;
       font-size: 15px;
       font-weight: 400;
@@ -48,6 +48,6 @@
 
 <style>
   input::placeholder {
-    color: #585650;
+    color: var(--text-faint);
   }
 </style>

--- a/src/lib/components/SettingsSection.svelte
+++ b/src/lib/components/SettingsSection.svelte
@@ -10,10 +10,10 @@
 </script>
 
 <section>
-  <h2 style="font-family:'Source Serif 4',serif;font-size:18px;font-weight:600;color:#D8D5CE;margin-bottom:12px;">
+  <h2 style="font-family:'Source Serif 4',serif;font-size:18px;font-weight:600;color:var(--text);margin-bottom:12px;">
     {title}
   </h2>
-  <div style="background:#242422;border-radius:8px;padding:16px;display:flex;flex-direction:column;gap:16px;">
+  <div style="background:var(--surface);border-radius:8px;padding:16px;display:flex;flex-direction:column;gap:16px;">
     {@render children()}
   </div>
 </section>

--- a/src/lib/components/SpeakerReview.svelte
+++ b/src/lib/components/SpeakerReview.svelte
@@ -2,7 +2,7 @@
   import { onMount } from "svelte";
   import { get } from "svelte/store";
   import { settings } from "../stores/settings";
-  import { getKnownParticipants, updateSpeakerLabels, retryProcessing } from "../tauri";
+  import { getKnownParticipants, updateSpeakerLabels, retryProcessing, getRecordingDir } from "../tauri";
 
   interface Props {
     speakerLabels: Record<string, number>;  // SPEAKER_XX -> utterance count
@@ -27,29 +27,8 @@
 
   let speakerCount = $derived(Object.keys(speakerLabels).length);
 
-  // Combined suggestions: calendar first, then known (deduplicated)
-  let allSuggestions = $derived.by(() => {
-    const seen = new Set<string>();
-    const result: { name: string; source: "calendar" | "known" }[] = [];
-    for (const name of calendarParticipants) {
-      if (!seen.has(name.toLowerCase())) {
-        seen.add(name.toLowerCase());
-        result.push({ name, source: "calendar" });
-      }
-    }
-    for (const name of knownParticipants) {
-      if (!seen.has(name.toLowerCase())) {
-        seen.add(name.toLowerCase());
-        result.push({ name, source: "known" });
-      }
-    }
-    return result;
-  });
-
-  function getRecordingDir(filePath: string): string {
-    const lastSep = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
-    return lastSep > 0 ? filePath.substring(0, lastSep) : filePath;
-  }
+  // Note: calendarParticipants and knownParticipants are used directly
+  // in the datalist options in the template below.
 
   onMount(async () => {
     try {

--- a/src/lib/components/SpeakerReview.svelte
+++ b/src/lib/components/SpeakerReview.svelte
@@ -1,0 +1,312 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { get } from "svelte/store";
+  import { settings } from "../stores/settings";
+  import { getKnownParticipants, updateSpeakerLabels, retryProcessing } from "../tauri";
+
+  interface Props {
+    speakerLabels: Record<string, number>;  // SPEAKER_XX -> utterance count
+    calendarParticipants?: string[];
+    recordingPath: string;
+    onResumed?: () => void;
+  }
+
+  let { speakerLabels, calendarParticipants = [], recordingPath, onResumed }: Props = $props();
+
+  let corrections: Record<string, string> = $state({});
+  let knownParticipants: string[] = $state([]);
+  let loading = $state(false);
+  let error: string | null = $state(null);
+
+  // Sort speakers by utterance count descending
+  let sortedSpeakers = $derived(
+    Object.entries(speakerLabels)
+      .sort(([, a], [, b]) => b - a)
+      .map(([speaker]) => speaker)
+  );
+
+  let speakerCount = $derived(Object.keys(speakerLabels).length);
+
+  // Combined suggestions: calendar first, then known (deduplicated)
+  let allSuggestions = $derived.by(() => {
+    const seen = new Set<string>();
+    const result: { name: string; source: "calendar" | "known" }[] = [];
+    for (const name of calendarParticipants) {
+      if (!seen.has(name.toLowerCase())) {
+        seen.add(name.toLowerCase());
+        result.push({ name, source: "calendar" });
+      }
+    }
+    for (const name of knownParticipants) {
+      if (!seen.has(name.toLowerCase())) {
+        seen.add(name.toLowerCase());
+        result.push({ name, source: "known" });
+      }
+    }
+    return result;
+  });
+
+  function getRecordingDir(filePath: string): string {
+    const lastSep = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
+    return lastSep > 0 ? filePath.substring(0, lastSep) : filePath;
+  }
+
+  onMount(async () => {
+    try {
+      const s = get(settings);
+      if (s.recordingsFolder) {
+        knownParticipants = await getKnownParticipants(s.recordingsFolder);
+      }
+    } catch (e) {
+      console.error("Failed to load known participants:", e);
+    }
+  });
+
+  async function applyAndResume() {
+    if (loading) return;
+    loading = true;
+    error = null;
+    try {
+      const recordingDir = getRecordingDir(recordingPath);
+      // Only send non-empty corrections
+      const filtered: Record<string, string> = {};
+      for (const [speaker, name] of Object.entries(corrections)) {
+        if (name.trim()) {
+          filtered[speaker] = name.trim();
+        }
+      }
+      if (Object.keys(filtered).length > 0) {
+        await updateSpeakerLabels(recordingDir, filtered);
+      }
+      await retryProcessing(recordingDir, "analyze");
+      onResumed?.();
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function skipAndResume() {
+    if (loading) return;
+    loading = true;
+    error = null;
+    try {
+      const recordingDir = getRecordingDir(recordingPath);
+      await retryProcessing(recordingDir, "analyze");
+      onResumed?.();
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+    } finally {
+      loading = false;
+    }
+  }
+</script>
+
+<div class="speaker-review">
+  <!-- Warning banner -->
+  <div class="warning-banner">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+      <line x1="12" y1="9" x2="12" y2="13" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
+    </svg>
+    <span>
+      {speakerCount} speaker{speakerCount !== 1 ? 's' : ''} could not be identified. Assign names below, or skip to use generic labels.
+    </span>
+  </div>
+
+  <!-- Speaker mapping rows -->
+  <div class="speaker-rows">
+    {#each sortedSpeakers as speaker, i (speaker)}
+      <div class="speaker-row">
+        <span class="speaker-label">{speaker}</span>
+        <svg class="arrow" width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M3 8h10M9 4l4 4-4 4" />
+        </svg>
+        <input
+          type="text"
+          class="speaker-input"
+          list="speaker-suggestions-{i}"
+          placeholder="Type or select a name..."
+          value={corrections[speaker] ?? ""}
+          oninput={(e) => { corrections[speaker] = (e.target as HTMLInputElement).value; }}
+        />
+        <datalist id="speaker-suggestions-{i}">
+          {#if calendarParticipants.length > 0}
+            {#each calendarParticipants as name}
+              <option value={name} label="{name} (calendar)" />
+            {/each}
+          {/if}
+          {#each knownParticipants as name}
+            <option value={name} label="{name} (known)" />
+          {/each}
+        </datalist>
+        <span class="utterance-count">{speakerLabels[speaker]} utterance{speakerLabels[speaker] !== 1 ? 's' : ''}</span>
+      </div>
+    {/each}
+  </div>
+
+  {#if error}
+    <div class="error-msg">{error}</div>
+  {/if}
+
+  <!-- Action buttons -->
+  <div class="action-buttons">
+    <button
+      class="btn-primary"
+      onclick={applyAndResume}
+      disabled={loading}
+    >
+      {loading ? "Applying..." : "Apply & Resume Pipeline"}
+    </button>
+    <button
+      class="btn-secondary"
+      onclick={skipAndResume}
+      disabled={loading}
+    >
+      {loading ? "Skipping..." : "Skip \u2014 Use Generic Labels"}
+    </button>
+  </div>
+</div>
+
+<style>
+  .speaker-review {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    font-family: 'DM Sans', sans-serif;
+  }
+
+  .warning-banner {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 16px;
+    border-radius: 8px;
+    background: rgba(196, 168, 77, 0.10);
+    color: var(--warning);
+    font-size: 14px;
+    line-height: 1.4;
+  }
+
+  .warning-banner svg {
+    flex-shrink: 0;
+  }
+
+  .speaker-rows {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .speaker-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    border-radius: 6px;
+    background: var(--surface);
+  }
+
+  .speaker-label {
+    font-size: 13.5px;
+    font-weight: 600;
+    color: var(--gold);
+    white-space: nowrap;
+    min-width: 110px;
+  }
+
+  .arrow {
+    flex-shrink: 0;
+    color: var(--text-faint);
+  }
+
+  .speaker-input {
+    flex: 1;
+    min-width: 0;
+    padding: 6px 10px;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    background: var(--bg);
+    color: var(--text);
+    font-family: 'DM Sans', sans-serif;
+    font-size: 13.5px;
+    outline: none;
+    transition: border-color 120ms ease;
+  }
+
+  .speaker-input::placeholder {
+    color: var(--text-faint);
+  }
+
+  .speaker-input:focus {
+    border-color: var(--gold);
+  }
+
+  .utterance-count {
+    font-size: 12.5px;
+    color: var(--text-muted);
+    white-space: nowrap;
+  }
+
+  .error-msg {
+    padding: 8px 12px;
+    border-radius: 6px;
+    background: rgba(200, 80, 60, 0.10);
+    color: var(--red);
+    font-size: 13.5px;
+  }
+
+  .action-buttons {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .btn-primary {
+    padding: 8px 18px;
+    border-radius: 6px;
+    border: none;
+    background: var(--gold);
+    color: var(--bg);
+    font-family: 'DM Sans', sans-serif;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 120ms ease;
+  }
+
+  .btn-primary:hover:not(:disabled) {
+    background: var(--gold-hover);
+  }
+
+  .btn-primary:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  .btn-secondary {
+    padding: 8px 18px;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--text-muted);
+    font-family: 'DM Sans', sans-serif;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+  }
+
+  .btn-secondary:hover:not(:disabled) {
+    background: var(--surface);
+    color: var(--text);
+    border-color: var(--border-bright);
+  }
+
+  .btn-secondary:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+</style>

--- a/src/lib/components/TodoistSettings.svelte
+++ b/src/lib/components/TodoistSettings.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { settings, saveSetting } from "../stores/settings";
 
-  const inputStyle = "width:100%;background:#282826;border:1px solid #262624;border-radius:6px;padding:6px 12px;font-size:15px;color:#D8D5CE;font-family:'DM Sans',sans-serif;outline:none;";
-  const labelStyle = "display:block;font-size:14px;color:#78756E;margin-bottom:4px;font-family:'DM Sans',sans-serif;";
+  const inputStyle = "width:100%;background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:6px 12px;font-size:15px;color:var(--text);font-family:'DM Sans',sans-serif;outline:none;";
+  const labelStyle = "display:block;font-size:14px;color:var(--text-muted);margin-bottom:4px;font-family:'DM Sans',sans-serif;";
 </script>
 
 <div style="display:flex;flex-direction:column;gap:12px;">

--- a/src/lib/components/VaultSettings.svelte
+++ b/src/lib/components/VaultSettings.svelte
@@ -11,8 +11,8 @@
     }
   }
 
-  const inputStyle = "width:100%;background:#282826;border:1px solid #262624;border-radius:6px;padding:6px 12px;font-size:15px;color:#D8D5CE;font-family:'DM Sans',sans-serif;outline:none;";
-  const labelStyle = "display:block;font-size:14px;color:#78756E;margin-bottom:4px;font-family:'DM Sans',sans-serif;";
+  const inputStyle = "width:100%;background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:6px 12px;font-size:15px;color:var(--text);font-family:'DM Sans',sans-serif;outline:none;";
+  const labelStyle = "display:block;font-size:14px;color:var(--text-muted);margin-bottom:4px;font-family:'DM Sans',sans-serif;";
 </script>
 
 <div style="display:flex;flex-direction:column;gap:12px;">
@@ -23,14 +23,14 @@
         type="text"
         value={$settings.vaultPath}
         onblur={async (e) => { const newValue = e.currentTarget.value; if (newValue !== $settings.vaultPath) { await saveSetting("vaultPath", newValue); await resetMeetings(); } }}
-        style="flex:1;background:#282826;border:1px solid #262624;border-radius:6px;padding:6px 12px;font-size:15px;color:#D8D5CE;font-family:'DM Sans',sans-serif;outline:none;"
+        style="flex:1;background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:6px 12px;font-size:15px;color:var(--text);font-family:'DM Sans',sans-serif;outline:none;"
         placeholder="Path to Obsidian vault"
       />
       <button
         onclick={browseVaultPath}
-        style="font-size:14.5px;background:#282826;border:1px solid #262624;border-radius:6px;padding:6px 12px;color:#B0ADA5;cursor:pointer;font-family:'DM Sans',sans-serif;"
-        onmouseenter={(e) => { e.currentTarget.style.background = '#2B2B28'; }}
-        onmouseleave={(e) => { e.currentTarget.style.background = '#282826'; }}
+        style="font-size:14.5px;background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:6px 12px;color:var(--text-secondary);cursor:pointer;font-family:'DM Sans',sans-serif;"
+        onmouseenter={(e) => { e.currentTarget.style.background = 'var(--raised)'; }}
+        onmouseleave={(e) => { e.currentTarget.style.background = 'var(--surface)'; }}
       >
         Browse
       </button>

--- a/src/lib/components/WhisperXSettings.svelte
+++ b/src/lib/components/WhisperXSettings.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { settings, saveSetting } from "../stores/settings";
 
-  const inputStyle = "width:100%;background:#282826;border:1px solid #262624;border-radius:6px;padding:6px 12px;font-size:15px;color:#D8D5CE;font-family:'DM Sans',sans-serif;outline:none;";
-  const labelStyle = "display:block;font-size:14px;color:#78756E;margin-bottom:4px;font-family:'DM Sans',sans-serif;";
+  const inputStyle = "width:100%;background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:6px 12px;font-size:15px;color:var(--text);font-family:'DM Sans',sans-serif;outline:none;";
+  const labelStyle = "display:block;font-size:14px;color:var(--text-muted);margin-bottom:4px;font-family:'DM Sans',sans-serif;";
 </script>
 
 <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;">

--- a/src/lib/dummy-data.ts
+++ b/src/lib/dummy-data.ts
@@ -12,7 +12,7 @@ import type {
   GraphNode,
   GraphEdge,
   CalendarEvent,
-  BriefingResponse,
+  Briefing,
 } from "./tauri";
 
 export const USE_DUMMY_DATA = import.meta.env.VITE_DUMMY_DATA === "true";
@@ -296,25 +296,18 @@ export const DUMMY_CALENDAR_EVENTS: CalendarEvent[] = [
 // Briefing response
 // ---------------------------------------------------------------------------
 
-export const DUMMY_BRIEFING: BriefingResponse = {
-  content: `## Acme Corp Follow-up
-
-**Participants:** Jane Smith (VP Engineering), Bob Jones (Senior DevOps)
-
-### Context
-- Last meeting on March 17 covered Q2 infrastructure modernization
-- Phase 1 (CI/CD) proposal was sent; awaiting feedback
-- Budget of $45K approved for Phase 1 tooling
-
-### Open Items
-- Jenkins audit with Acme DevOps team (not yet scheduled)
-- AWS account access pending from Acme IT
-- Bob's GitHub Actions proof-of-concept repo (in progress)
-
-### Suggested Talking Points
-- Get feedback on the Phase 1 proposal timeline
-- Confirm Jenkins audit date
-- Discuss AWS account access status`,
-  generated_at: "2026-03-19T13:45:00",
-  event_id: "cal-002",
+export const DUMMY_BRIEFING: Briefing = {
+  topics: [
+    "Phase 1 (CI/CD) proposal feedback and timeline",
+    "Jenkins audit scheduling with Acme DevOps team",
+    "AWS account access status from Acme IT",
+  ],
+  action_items: [
+    { assignee: "Tim", description: "Send Phase 1 proposal with detailed timeline by Friday", from_meeting: "Project Kickoff with Acme Corp" },
+    { assignee: "Jane Smith", description: "Review and share Globex migration runbook", from_meeting: "Project Kickoff with Acme Corp" },
+    { assignee: "Bob Jones", description: "Set up GitHub Actions proof-of-concept repo", from_meeting: "Project Kickoff with Acme Corp" },
+  ],
+  context: "Last meeting on March 17 covered Q2 infrastructure modernization. Budget of $45K approved for Phase 1 tooling. Moving from Jenkins to GitHub Actions, then Kubernetes on EKS for Phase 2.",
+  relationship_summary: "Jane is the key technical decision-maker at Acme. Bob defers to her on architecture choices. Alice is new to the team (joined 2 weeks ago).",
+  first_meeting: false,
 };

--- a/src/lib/dummy-data.ts
+++ b/src/lib/dummy-data.ts
@@ -11,6 +11,8 @@ import type {
   Utterance,
   GraphNode,
   GraphEdge,
+  CalendarEvent,
+  BriefingResponse,
 } from "./tauri";
 
 export const USE_DUMMY_DATA = import.meta.env.VITE_DUMMY_DATA === "true";
@@ -20,14 +22,14 @@ export const USE_DUMMY_DATA = import.meta.env.VITE_DUMMY_DATA === "true";
 // ---------------------------------------------------------------------------
 
 function doneStatus(): PipelineStatus {
-  const done = { completed: true, timestamp: "2026-03-17T10:00:00", error: null };
+  const done = { completed: true, timestamp: "2026-03-17T10:00:00", error: null, waiting: null };
   return { merge: done, frames: done, transcribe: done, diarize: done, analyze: done, export: done };
 }
 
 function failedStatus(stage: string): PipelineStatus {
-  const done = { completed: true, timestamp: "2026-03-17T10:00:00", error: null };
-  const fail = { completed: false, timestamp: null, error: `${stage} failed: CUDA out of memory` };
-  const pending = { completed: false, timestamp: null, error: null };
+  const done = { completed: true, timestamp: "2026-03-17T10:00:00", error: null, waiting: null };
+  const fail = { completed: false, timestamp: null, error: `${stage} failed: CUDA out of memory`, waiting: null };
+  const pending = { completed: false, timestamp: null, error: null, waiting: null };
   const s: any = { merge: done, frames: done, transcribe: done, diarize: done, analyze: done, export: done };
   s[stage] = fail;
   const stages = ["merge", "frames", "transcribe", "diarize", "analyze", "export"];
@@ -37,9 +39,16 @@ function failedStatus(stage: string): PipelineStatus {
 }
 
 function processingStatus(): PipelineStatus {
-  const done = { completed: true, timestamp: "2026-03-17T10:00:00", error: null };
-  const pending = { completed: false, timestamp: null, error: null };
+  const done = { completed: true, timestamp: "2026-03-17T10:00:00", error: null, waiting: null };
+  const pending = { completed: false, timestamp: null, error: null, waiting: null };
   return { merge: done, frames: done, transcribe: pending, diarize: pending, analyze: pending, export: pending };
+}
+
+function waitingForSpeakerReviewStatus(): PipelineStatus {
+  const done = { completed: true, timestamp: "2026-03-17T10:00:00", error: null, waiting: null };
+  const waiting = { completed: false, timestamp: null, error: null, waiting: "speaker_review" };
+  const pending = { completed: false, timestamp: null, error: null, waiting: null };
+  return { merge: done, frames: done, transcribe: done, diarize: done, analyze: waiting, export: pending };
 }
 
 // ---------------------------------------------------------------------------
@@ -55,6 +64,7 @@ export const DUMMY_MEETINGS: MeetingSummary[] = [
   { id: "2026-03-15-investor-update", title: "Investor Update Call", date: "2026-03-15", platform: "zoom", participants: ["Tim", "Jane Smith", "Investor A"], company: null, duration_seconds: 3000, pipeline_status: doneStatus(), has_note: true, has_transcript: true, has_video: true, recording_path: null, note_path: null },
   { id: "2026-03-15-1on1-sarah", title: "1:1 with Sarah", date: "2026-03-15", platform: "zoom", participants: ["Tim", "Sarah"], company: null, duration_seconds: 1800, pipeline_status: doneStatus(), has_note: true, has_transcript: true, has_video: false, recording_path: null, note_path: null },
   { id: "2026-03-14-product-planning", title: "Product Planning Session", date: "2026-03-14", platform: "zoho", participants: ["Tim", "Mike", "Lisa", "Product Team"], company: null, duration_seconds: 5400, pipeline_status: doneStatus(), has_note: true, has_transcript: true, has_video: true, recording_path: null, note_path: null },
+  { id: "2026-03-17-sales-demo", title: "Sales Demo with Initech", date: "2026-03-17", platform: "zoom", participants: [], company: "Initech", duration_seconds: 2100, pipeline_status: waitingForSpeakerReviewStatus(), has_note: false, has_transcript: false, has_video: true, recording_path: "C:/Recordings/2026-03-17-sales-demo/recording.mp4", note_path: null },
 ];
 
 export const DUMMY_FILTER_OPTIONS: FilterOptions = {
@@ -219,4 +229,92 @@ export const DUMMY_GRAPH_DATA = {
     { source: "person:dave-wilson", target: "company:globex", edge_type: "works_at" },
     { source: "person:mike", target: "company:initech", edge_type: "works_at" },
   ] as GraphEdge[],
+};
+
+// ---------------------------------------------------------------------------
+// Calendar events
+// ---------------------------------------------------------------------------
+
+export const DUMMY_CALENDAR_EVENTS: CalendarEvent[] = [
+  {
+    id: "cal-001",
+    title: "Sprint Planning",
+    description: "Bi-weekly sprint planning for Q2 goals",
+    start: "2026-03-19T09:00:00",
+    end: "2026-03-19T10:00:00",
+    participants: [
+      { name: "Tim", email: "tim@example.com" },
+      { name: "Sarah", email: "sarah@example.com" },
+      { name: "Mike", email: "mike@example.com" },
+    ],
+    location: "Zoom",
+  },
+  {
+    id: "cal-002",
+    title: "Acme Corp Follow-up",
+    description: "Review Phase 1 proposal feedback",
+    start: "2026-03-19T14:00:00",
+    end: "2026-03-19T14:45:00",
+    participants: [
+      { name: "Tim", email: "tim@example.com" },
+      { name: "Jane Smith", email: "jane@acme.com" },
+      { name: "Bob Jones", email: "bob@acme.com" },
+    ],
+    location: null,
+  },
+  {
+    id: "cal-003",
+    title: "Project Kickoff with Acme Corp",
+    description: "Q2 infrastructure modernization kickoff",
+    start: "2026-03-17T09:00:00",
+    end: "2026-03-17T09:45:00",
+    participants: [
+      { name: "Tim", email: "tim@example.com" },
+      { name: "Jane Smith", email: "jane@acme.com" },
+      { name: "Bob Jones", email: "bob@acme.com" },
+      { name: "Alice Chen", email: "alice@acme.com" },
+    ],
+    location: "Zoom",
+  },
+  {
+    id: "cal-004",
+    title: "Design Sprint Retro",
+    description: null,
+    start: "2026-03-16T15:00:00",
+    end: "2026-03-16T15:40:00",
+    participants: [
+      { name: "Sarah", email: "sarah@example.com" },
+      { name: "Mike", email: "mike@example.com" },
+      { name: "Lisa", email: "lisa@example.com" },
+      { name: "Tim", email: "tim@example.com" },
+    ],
+    location: "Google Meet",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Briefing response
+// ---------------------------------------------------------------------------
+
+export const DUMMY_BRIEFING: BriefingResponse = {
+  content: `## Acme Corp Follow-up
+
+**Participants:** Jane Smith (VP Engineering), Bob Jones (Senior DevOps)
+
+### Context
+- Last meeting on March 17 covered Q2 infrastructure modernization
+- Phase 1 (CI/CD) proposal was sent; awaiting feedback
+- Budget of $45K approved for Phase 1 tooling
+
+### Open Items
+- Jenkins audit with Acme DevOps team (not yet scheduled)
+- AWS account access pending from Acme IT
+- Bob's GitHub Actions proof-of-concept repo (in progress)
+
+### Suggested Talking Points
+- Get feedback on the Phase 1 proposal timeline
+- Confirm Jenkins audit date
+- Discuss AWS account access status`,
+  generated_at: "2026-03-19T13:45:00",
+  event_id: "cal-002",
 };

--- a/src/lib/stores/meetings.ts
+++ b/src/lib/stores/meetings.ts
@@ -5,6 +5,7 @@ import {
   listMeetings,
   searchMeetings,
   getFilterOptions,
+  invalidateBriefingCache,
   type MeetingSummary,
   type FilterOptions,
 } from "../tauri";
@@ -246,12 +247,21 @@ let unlistenPipeline: (() => void) | null = null;
 
 export async function initMeetingsListener(): Promise<void> {
   if (unlistenPipeline) return;
-  unlistenPipeline = await listen("pipeline-completed", () => {
+  unlistenPipeline = await listen("pipeline-completed", async () => {
     const current = get(meetings);
     if (current.searchQuery) {
-      search(current.searchQuery);
+      await search(current.searchQuery);
     } else {
-      loadMeetings();
+      await loadMeetings();
+    }
+
+    // Invalidate briefing cache for participants of the most recently updated meeting
+    const updated = get(meetings);
+    if (updated.items.length > 0) {
+      const participants = updated.items[0].participants;
+      if (participants.length > 0) {
+        invalidateBriefingCache(participants).catch(() => {});
+      }
     }
   });
 }

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -20,6 +20,8 @@ export interface AppSettings {
   timeoutAction: "record" | "skip";
   notificationTimeoutSeconds: number;
   zoomLevel: number;
+  meetingNotifications: boolean;
+  meetingLeadTimeMinutes: number;
 }
 
 const defaults: AppSettings = {
@@ -41,6 +43,8 @@ const defaults: AppSettings = {
   timeoutAction: "record",
   notificationTimeoutSeconds: 60,
   zoomLevel: 1.0,
+  meetingNotifications: true,
+  meetingLeadTimeMinutes: 10,
 };
 
 export const settings = writable<AppSettings>({ ...defaults });

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -19,6 +19,7 @@ export interface AppSettings {
   detectionAction: "ask" | "always_record" | "never_record";
   timeoutAction: "record" | "skip";
   notificationTimeoutSeconds: number;
+  zoomLevel: number;
 }
 
 const defaults: AppSettings = {
@@ -39,6 +40,7 @@ const defaults: AppSettings = {
   detectionAction: "ask",
   timeoutAction: "record",
   notificationTimeoutSeconds: 60,
+  zoomLevel: 1.0,
 };
 
 export const settings = writable<AppSettings>({ ...defaults });

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -61,6 +61,7 @@ export interface PipelineStageStatus {
   completed: boolean;
   timestamp: string | null;
   error: string | null;
+  waiting: string | null;
 }
 
 // Full pipeline status (matches Rust PipelineStatus)

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -293,16 +293,40 @@ export async function getCalendarMatches(
   return invoke("get_calendar_matches", { recordingsDir });
 }
 
-// Briefing types (matches Rust BriefingResponse)
-export interface BriefingResponse {
-  content: string;
-  generated_at: string;
-  event_id: string;
+// Briefing types (matches Rust Briefing, BriefingActionItem)
+export interface BriefingActionItem {
+  assignee: string;
+  description: string;
+  from_meeting: string;
+}
+
+export interface Briefing {
+  topics: string[];
+  action_items: BriefingActionItem[];
+  context: string;
+  relationship_summary: string;
+  first_meeting: boolean;
 }
 
 // Briefing IPC
-export async function getBriefing(eventId: string): Promise<BriefingResponse> {
-  return invoke("get_briefing", { eventId });
+export async function generateBriefing(
+  eventId: string,
+  title: string,
+  participants: string[],
+  time: string,
+  recordingsDir: string,
+  vaultMeetingsDir?: string,
+  eventDescription?: string
+): Promise<Briefing> {
+  return invoke("generate_briefing", {
+    eventId,
+    title,
+    participants,
+    time,
+    recordingsDir,
+    vaultMeetingsDir: vaultMeetingsDir ?? null,
+    eventDescription: eventDescription ?? null,
+  });
 }
 
 export async function invalidateBriefingCache(

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -287,6 +287,10 @@ export async function syncCalendar(): Promise<CalendarCache> {
   return invoke("sync_calendar");
 }
 
+export async function getCalendarLastSynced(): Promise<string | null> {
+  return invoke("get_calendar_last_synced");
+}
+
 export async function getCalendarMatches(
   recordingsDir: string
 ): Promise<Record<string, string>> {
@@ -333,4 +337,11 @@ export async function invalidateBriefingCache(
   participantNames: string[]
 ): Promise<void> {
   return invoke("invalidate_briefing_cache", { participantNames });
+}
+
+// Shared utilities
+
+export function getRecordingDir(filePath: string): string {
+  const lastSep = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
+  return lastSep > 0 ? filePath.substring(0, lastSep) : filePath;
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -222,6 +222,18 @@ export async function retryProcessing(
   });
 }
 
+// Speaker label correction IPC
+export async function getKnownParticipants(recordingsDir: string): Promise<string[]> {
+  return invoke('get_known_participants', { recordingsDir });
+}
+
+export async function updateSpeakerLabels(
+  recordingDir: string,
+  corrections: Record<string, string>
+): Promise<void> {
+  return invoke('update_speaker_labels', { recordingDir, corrections });
+}
+
 // Filter options IPC
 export async function getFilterOptions(
   recordingsDir: string
@@ -234,4 +246,49 @@ export async function getGraphData(
   recordingsDir: string
 ): Promise<GraphData> {
   return invoke("get_graph_data", { recordingsDir });
+}
+
+// Calendar types (matches Rust CalendarEvent, CalendarParticipant, CalendarCache)
+export interface CalendarParticipant {
+  name: string;
+  email: string | null;
+}
+
+export interface CalendarEvent {
+  id: string;
+  title: string;
+  description: string | null;
+  start: string;
+  end: string;
+  participants: CalendarParticipant[];
+  location: string | null;
+}
+
+export interface CalendarCache {
+  events: CalendarEvent[];
+  last_synced: string;
+}
+
+// Calendar IPC
+export async function fetchCalendarEvents(
+  startDate: string,
+  endDate: string
+): Promise<CalendarEvent[]> {
+  return invoke("fetch_calendar_events", { startDate, endDate });
+}
+
+export async function getUpcomingMeetings(
+  hoursAhead: number
+): Promise<CalendarEvent[]> {
+  return invoke("get_upcoming_meetings", { hoursAhead });
+}
+
+export async function syncCalendar(): Promise<CalendarCache> {
+  return invoke("sync_calendar");
+}
+
+export async function getCalendarMatches(
+  recordingsDir: string
+): Promise<Record<string, string>> {
+  return invoke("get_calendar_matches", { recordingsDir });
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -292,3 +292,21 @@ export async function getCalendarMatches(
 ): Promise<Record<string, string>> {
   return invoke("get_calendar_matches", { recordingsDir });
 }
+
+// Briefing types (matches Rust BriefingResponse)
+export interface BriefingResponse {
+  content: string;
+  generated_at: string;
+  event_id: string;
+}
+
+// Briefing IPC
+export async function getBriefing(eventId: string): Promise<BriefingResponse> {
+  return invoke("get_briefing", { eventId });
+}
+
+export async function invalidateBriefingCache(
+  participantNames: string[]
+): Promise<void> {
+  return invoke("invalidate_briefing_cache", { participantNames });
+}

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,11 @@
+/** Shared color palettes for speaker and company visualization. */
+
+export const SPEAKER_COLORS = [
+  '#C4A84D', '#5e9e96', '#8e6e9e', '#9e826e',
+  '#6e829e', '#9e6e7e', '#7e9e6e', '#9e9e6e',
+];
+
+export const COMPANY_COLORS = [
+  '#5e9e96', '#8e6e9e', '#9e826e',
+  '#6e829e', '#9e6e7e', '#7e9e6e', '#9e9e6e',
+];

--- a/src/routes/Calendar.svelte
+++ b/src/routes/Calendar.svelte
@@ -10,6 +10,7 @@
     type CalendarEvent,
     type CalendarCache,
   } from "../lib/tauri";
+  import BriefingPanel from "../lib/components/BriefingPanel.svelte";
 
   let upcoming: CalendarEvent[] = $state([]);
   let past: CalendarEvent[] = $state([]);
@@ -20,6 +21,11 @@
   let error: string | null = $state(null);
 
   let zohoConnected = $state(false);
+  let expandedEventId: string | null = $state(null);
+
+  function toggleBriefing(eventId: string) {
+    expandedEventId = expandedEventId === eventId ? null : eventId;
+  }
 
   // Relative time formatting
   function relativeTime(iso: string): string {
@@ -251,44 +257,78 @@
         <div style="display: flex; flex-direction: column; gap: 6px;">
           {#each upcoming as event}
             {@const matchedId = matches[event.id]}
+            {@const isExpanded = expandedEventId === event.id}
             <div
               style="
                 background: var(--surface);
-                border: 1px solid var(--border);
+                border: 1px solid {isExpanded ? 'var(--gold)' : 'var(--border)'};
                 border-radius: 8px;
-                padding: 14px 18px;
-                display: flex;
-                align-items: center;
-                gap: 14px;
+                overflow: hidden;
               "
             >
-              <div style="flex: 1; min-width: 0;">
-                <div style="display: flex; align-items: center; gap: 8px;">
-                  <span style="font-size: 14.5px; font-weight: 500; color: var(--text);">
-                    {event.title}
-                  </span>
-                  {#if matchedId}
-                    <a
-                      href="#meeting/{matchedId}"
-                      title="View recording"
-                      style="
-                        color: var(--gold);
-                        text-decoration: none;
-                        font-size: 14px;
-                        flex-shrink: 0;
-                      "
-                    >&#x1F517;</a>
+              <button
+                onclick={() => toggleBriefing(event.id)}
+                style="
+                  width: 100%;
+                  background: none;
+                  border: none;
+                  padding: 14px 18px;
+                  display: flex;
+                  align-items: center;
+                  gap: 14px;
+                  cursor: pointer;
+                  text-align: left;
+                  font-family: 'DM Sans', sans-serif;
+                "
+              >
+                <div style="flex: 1; min-width: 0;">
+                  <div style="display: flex; align-items: center; gap: 8px;">
+                    <span style="font-size: 14.5px; font-weight: 500; color: var(--text);">
+                      {event.title}
+                    </span>
+                    {#if matchedId}
+                      <a
+                        href="#meeting/{matchedId}"
+                        title="View recording"
+                        onclick={(e) => e.stopPropagation()}
+                        style="
+                          color: var(--gold);
+                          text-decoration: none;
+                          font-size: 14px;
+                          flex-shrink: 0;
+                        "
+                      >&#x1F517;</a>
+                    {/if}
+                  </div>
+                  <div style="font-size: 13px; color: var(--text-muted); margin-top: 3px;">
+                    {formatDate(event.start)} &middot; {formatTimeRange(event.start, event.end)}
+                  </div>
+                  {#if event.participants.length > 0}
+                    <div style="font-size: 12.5px; color: var(--text-faint); margin-top: 3px;">
+                      {event.participants.map(p => p.name).join(", ")}
+                    </div>
                   {/if}
                 </div>
-                <div style="font-size: 13px; color: var(--text-muted); margin-top: 3px;">
-                  {formatDate(event.start)} &middot; {formatTimeRange(event.start, event.end)}
-                </div>
-                {#if event.participants.length > 0}
-                  <div style="font-size: 12.5px; color: var(--text-faint); margin-top: 3px;">
-                    {event.participants.map(p => p.name).join(", ")}
-                  </div>
-                {/if}
-              </div>
+                <span
+                  style="
+                    color: var(--text-faint);
+                    font-size: 12px;
+                    flex-shrink: 0;
+                    transform: rotate({isExpanded ? '180deg' : '0deg'});
+                    transition: transform 0.15s ease;
+                  "
+                >&#9660;</span>
+              </button>
+
+              {#if isExpanded}
+                <BriefingPanel
+                  eventId={event.id}
+                  title={event.title}
+                  participants={event.participants.map(p => p.name)}
+                  time={event.start}
+                  eventDescription={event.description ?? undefined}
+                />
+              {/if}
             </div>
           {/each}
         </div>

--- a/src/routes/Calendar.svelte
+++ b/src/routes/Calendar.svelte
@@ -1,0 +1,360 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { get } from "svelte/store";
+  import { settings } from "../lib/stores/settings";
+  import { credentials } from "../lib/stores/credentials";
+  import {
+    syncCalendar,
+    getUpcomingMeetings,
+    getCalendarMatches,
+    type CalendarEvent,
+    type CalendarCache,
+  } from "../lib/tauri";
+
+  let upcoming: CalendarEvent[] = $state([]);
+  let past: CalendarEvent[] = $state([]);
+  let matches: Record<string, string> = $state({});
+  let lastSynced: string | null = $state(null);
+  let loading = $state(true);
+  let syncing = $state(false);
+  let error: string | null = $state(null);
+
+  let zohoConnected = $state(false);
+
+  // Relative time formatting
+  function relativeTime(iso: string): string {
+    const diff = Date.now() - new Date(iso).getTime();
+    const mins = Math.floor(diff / 60_000);
+    if (mins < 1) return "just now";
+    if (mins < 60) return `${mins} min ago`;
+    const hours = Math.floor(mins / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    return `${days}d ago`;
+  }
+
+  function formatDate(iso: string): string {
+    return new Date(iso).toLocaleDateString(undefined, {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+    });
+  }
+
+  function formatTime(iso: string): string {
+    return new Date(iso).toLocaleTimeString(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  }
+
+  function formatTimeRange(start: string, end: string): string {
+    return `${formatTime(start)} – ${formatTime(end)}`;
+  }
+
+  async function doSync() {
+    syncing = true;
+    try {
+      const cache: CalendarCache = await syncCalendar();
+      lastSynced = cache.last_synced;
+      await loadEvents();
+    } catch (err) {
+      console.error("Calendar sync failed:", err);
+    } finally {
+      syncing = false;
+    }
+  }
+
+  async function loadEvents() {
+    const s = get(settings);
+    try {
+      // Upcoming: next 7 days
+      upcoming = await getUpcomingMeetings(168);
+
+      // Past: last 30 days — fetch via getUpcomingMeetings with negative trick won't work,
+      // so we use fetchCalendarEvents for the past range
+      const { fetchCalendarEvents } = await import("../lib/tauri");
+      const now = new Date();
+      const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+      const allPast = await fetchCalendarEvents(
+        thirtyDaysAgo.toISOString(),
+        now.toISOString()
+      );
+      // Filter to only past events and sort newest first
+      past = allPast
+        .filter((e) => new Date(e.start).getTime() < now.getTime())
+        .sort((a, b) => new Date(b.start).getTime() - new Date(a.start).getTime());
+
+      // Get recording matches
+      if (s.recordingsFolder) {
+        matches = await getCalendarMatches(s.recordingsFolder);
+      }
+    } catch (err) {
+      error = String(err);
+      console.error("Failed to load calendar events:", err);
+    }
+  }
+
+  onMount(async () => {
+    // Subscribe to credentials to track Zoho status reactively
+    const unsub = credentials.subscribe((creds) => {
+      zohoConnected = creds.zoho.status === "connected";
+    });
+
+    if (!zohoConnected) {
+      loading = false;
+      return;
+    }
+
+    try {
+      await loadEvents();
+
+      // Auto-sync if last sync was >15 min ago
+      if (lastSynced) {
+        const diff = Date.now() - new Date(lastSynced).getTime();
+        if (diff > 15 * 60 * 1000) {
+          doSync();
+        }
+      } else {
+        // No sync timestamp — sync now
+        doSync();
+      }
+    } catch (err) {
+      error = String(err);
+    } finally {
+      loading = false;
+    }
+
+    return () => unsub();
+  });
+</script>
+
+<div
+  class="h-full overflow-y-auto"
+  style="font-family: 'DM Sans', sans-serif; padding: 32px 40px;"
+>
+  <!-- Header -->
+  <div style="display: flex; align-items: center; gap: 16px; margin-bottom: 28px;">
+    <h1
+      style="
+        font-family: 'Source Serif 4', serif;
+        font-size: 24px;
+        font-weight: 700;
+        color: var(--text);
+        margin: 0;
+      "
+    >Calendar</h1>
+
+    {#if lastSynced}
+      <span style="font-size: 13px; color: var(--text-muted);">
+        Synced {relativeTime(lastSynced)}
+      </span>
+    {/if}
+
+    <button
+      onclick={doSync}
+      disabled={syncing}
+      style="
+        margin-left: auto;
+        padding: 6px 16px;
+        font-size: 13px;
+        font-family: 'DM Sans', sans-serif;
+        border-radius: 6px;
+        border: 1px solid var(--border);
+        background: var(--surface);
+        color: var(--text);
+        cursor: {syncing ? 'wait' : 'pointer'};
+        opacity: {syncing ? 0.6 : 1};
+      "
+    >
+      {syncing ? "Syncing..." : "Sync Now"}
+    </button>
+  </div>
+
+  {#if !zohoConnected}
+    <!-- Empty state: Zoho not connected -->
+    <div
+      style="
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 80px 20px;
+        text-align: center;
+      "
+    >
+      <div style="font-size: 15px; color: var(--text-muted); margin-bottom: 12px;">
+        No calendar connected
+      </div>
+      <a
+        href="#settings"
+        style="
+          font-size: 14px;
+          color: var(--gold);
+          text-decoration: none;
+        "
+      >Connect Zoho Calendar in Settings</a>
+    </div>
+  {:else if loading}
+    <div style="color: var(--text-faint); font-size: 14px; padding: 40px 0; text-align: center;">
+      Loading calendar events...
+    </div>
+  {:else if error}
+    <div
+      style="
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 24px;
+        text-align: center;
+      "
+    >
+      <div style="color: var(--text-muted); font-size: 14px; margin-bottom: 8px;">
+        Failed to load calendar
+      </div>
+      <div style="color: var(--text-faint); font-size: 13px;">{error}</div>
+    </div>
+  {:else if upcoming.length === 0 && past.length === 0}
+    <!-- Empty state: no events -->
+    <div
+      style="
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 80px 20px;
+        text-align: center;
+      "
+    >
+      <div style="font-size: 15px; color: var(--text-muted);">
+        No calendar events found
+      </div>
+      <div style="font-size: 13px; color: var(--text-faint); margin-top: 8px;">
+        Events from the past 30 days and next 7 days will appear here
+      </div>
+    </div>
+  {:else}
+    <!-- Upcoming meetings -->
+    {#if upcoming.length > 0}
+      <section style="margin-bottom: 36px;">
+        <h2
+          style="
+            font-size: 14px;
+            font-weight: 600;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            margin: 0 0 12px 0;
+          "
+        >Upcoming</h2>
+
+        <div style="display: flex; flex-direction: column; gap: 6px;">
+          {#each upcoming as event}
+            {@const matchedId = matches[event.id]}
+            <div
+              style="
+                background: var(--surface);
+                border: 1px solid var(--border);
+                border-radius: 8px;
+                padding: 14px 18px;
+                display: flex;
+                align-items: center;
+                gap: 14px;
+              "
+            >
+              <div style="flex: 1; min-width: 0;">
+                <div style="display: flex; align-items: center; gap: 8px;">
+                  <span style="font-size: 14.5px; font-weight: 500; color: var(--text);">
+                    {event.title}
+                  </span>
+                  {#if matchedId}
+                    <a
+                      href="#meeting/{matchedId}"
+                      title="View recording"
+                      style="
+                        color: var(--gold);
+                        text-decoration: none;
+                        font-size: 14px;
+                        flex-shrink: 0;
+                      "
+                    >&#x1F517;</a>
+                  {/if}
+                </div>
+                <div style="font-size: 13px; color: var(--text-muted); margin-top: 3px;">
+                  {formatDate(event.start)} &middot; {formatTimeRange(event.start, event.end)}
+                </div>
+                {#if event.participants.length > 0}
+                  <div style="font-size: 12.5px; color: var(--text-faint); margin-top: 3px;">
+                    {event.participants.map(p => p.name).join(", ")}
+                  </div>
+                {/if}
+              </div>
+            </div>
+          {/each}
+        </div>
+      </section>
+    {/if}
+
+    <!-- Past events -->
+    {#if past.length > 0}
+      <section>
+        <h2
+          style="
+            font-size: 14px;
+            font-weight: 600;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            margin: 0 0 12px 0;
+          "
+        >Past 30 Days</h2>
+
+        <div style="display: flex; flex-direction: column; gap: 6px;">
+          {#each past as event}
+            {@const matchedId = matches[event.id]}
+            <div
+              style="
+                background: var(--surface);
+                border: 1px solid var(--border);
+                border-radius: 8px;
+                padding: 12px 18px;
+                display: flex;
+                align-items: center;
+                gap: 14px;
+                opacity: 0.85;
+              "
+            >
+              <div style="flex: 1; min-width: 0;">
+                <div style="display: flex; align-items: center; gap: 8px;">
+                  <span style="font-size: 14px; font-weight: 500; color: var(--text);">
+                    {event.title}
+                  </span>
+                  {#if matchedId}
+                    <a
+                      href="#meeting/{matchedId}"
+                      title="View recording"
+                      style="
+                        color: var(--gold);
+                        text-decoration: none;
+                        font-size: 14px;
+                        flex-shrink: 0;
+                      "
+                    >&#x1F517;</a>
+                  {/if}
+                </div>
+                <div style="font-size: 13px; color: var(--text-muted); margin-top: 2px;">
+                  {formatDate(event.start)} &middot; {formatTimeRange(event.start, event.end)}
+                </div>
+                {#if event.participants.length > 0}
+                  <div style="font-size: 12.5px; color: var(--text-faint); margin-top: 2px;">
+                    {event.participants.map(p => p.name).join(", ")}
+                  </div>
+                {/if}
+              </div>
+            </div>
+          {/each}
+        </div>
+      </section>
+    {/if}
+  {/if}
+</div>

--- a/src/routes/Calendar.svelte
+++ b/src/routes/Calendar.svelte
@@ -7,6 +7,7 @@
     syncCalendar,
     getUpcomingMeetings,
     getCalendarMatches,
+    getCalendarLastSynced,
     type CalendarEvent,
     type CalendarCache,
   } from "../lib/tauri";
@@ -65,6 +66,7 @@
       lastSynced = cache.last_synced;
       await loadEvents();
     } catch (err) {
+      error = String(err);
       console.error("Calendar sync failed:", err);
     } finally {
       syncing = false;
@@ -102,7 +104,9 @@
   }
 
   onMount(async () => {
-    // Subscribe to credentials to track Zoho status reactively
+    // Subscribe to credentials to track Zoho status reactively.
+    // Svelte store .subscribe() calls the callback synchronously with the
+    // current value, so zohoConnected is set before the if-check below.
     const unsub = credentials.subscribe((creds) => {
       zohoConnected = creds.zoho.status === "connected";
     });
@@ -113,17 +117,21 @@
     }
 
     try {
-      await loadEvents();
+      // Read cached sync timestamp to decide whether to sync or just load
+      lastSynced = await getCalendarLastSynced();
 
-      // Auto-sync if last sync was >15 min ago
       if (lastSynced) {
         const diff = Date.now() - new Date(lastSynced).getTime();
         if (diff > 15 * 60 * 1000) {
-          doSync();
+          // Stale cache — sync (which loads events after syncing)
+          await doSync();
+        } else {
+          // Fresh cache — just load events from cache
+          await loadEvents();
         }
       } else {
-        // No sync timestamp — sync now
-        doSync();
+        // No cache — sync now (which loads events after syncing)
+        await doSync();
       }
     } catch (err) {
       error = String(err);

--- a/src/routes/Dashboard.svelte
+++ b/src/routes/Dashboard.svelte
@@ -96,7 +96,7 @@
   );
 </script>
 
-<div class="flex flex-col h-full" style="background: #1D1D1B;">
+<div class="flex flex-col h-full" style="background: var(--bg);">
   <RecordingStatusBar />
 
   <div class="flex flex-1 overflow-hidden">
@@ -127,8 +127,8 @@
             height: 36px;
             border-radius: 8px;
             border: none;
-            background: {filtersExpanded ? 'rgba(168,160,120,0.12)' : '#282826'};
-            color: {filtersExpanded ? '#A8A078' : '#585650'};
+            background: {filtersExpanded ? 'rgba(168,160,120,0.12)' : 'var(--surface)'};
+            color: {filtersExpanded ? 'var(--gold)' : 'var(--text-faint)'};
             cursor: pointer;
             flex-shrink: 0;
             position: relative;
@@ -154,8 +154,8 @@
                 position: absolute;
                 top: -4px;
                 right: -4px;
-                background: #A8A078;
-                color: #1A1A18;
+                background: var(--gold);
+                color: var(--bg);
                 font-size: 9px;
                 font-weight: 700;
                 font-family: 'DM Sans', sans-serif;
@@ -180,7 +180,7 @@
           class="mt-4 p-3 rounded-lg"
           style="
             background: rgba(200,80,60,0.10);
-            color: #D06850;
+            color: var(--red);
             font-family: 'DM Sans', sans-serif;
             font-size: 14.5px;
           "
@@ -196,7 +196,7 @@
             background: rgba(180,165,130,0.08);
             font-family: 'DM Sans', sans-serif;
             font-size: 14.5px;
-            color: #B4A882;
+            color: var(--gold-muted);
             text-align: center;
           "
         >
@@ -204,7 +204,7 @@
           <a
             href="#settings"
             style="
-              color: #A8A078;
+              color: var(--gold);
               text-decoration: underline;
               font-weight: 600;
             "

--- a/src/routes/GraphView.svelte
+++ b/src/routes/GraphView.svelte
@@ -29,12 +29,13 @@
 
   // ── Company color palette (configurable) ──
   const COMPANY_PALETTE = [
-    "#B4A882",
-    "#82A8B4",
-    "#B48282",
-    "#82B498",
-    "#A882B4",
-    "#B4A068",
+    "#5e9e96",
+    "#8e6e9e",
+    "#9e826e",
+    "#6e829e",
+    "#9e6e7e",
+    "#7e9e6e",
+    "#9e9e6e",
   ];
 
   let svgEl: SVGSVGElement | undefined = $state(undefined);
@@ -87,12 +88,12 @@
   };
 
   function getColor(node: SimNode): string {
-    if (node.node_type === "meeting") return "#A8A078";
-    if (node.node_type === "person") return "#78756E";
+    if (node.node_type === "meeting") return "#C4A84D";
+    if (node.node_type === "person") return "#7a8493";
     if (node.node_type === "company") {
-      return companyColorMap.get(node.id) ?? "#B4A882";
+      return companyColorMap.get(node.id) ?? "#b09840";
     }
-    return "#78756E";
+    return "#7a8493";
   }
 
   function getRadius(nodeType: string): number {
@@ -112,8 +113,8 @@
   // Build groups list for controls panel
   let controlGroups = $derived.by(() => {
     const groups = [
-      { label: "Meeting", color: "#A8A078" },
-      { label: "Person", color: "#78756E" },
+      { label: "Meeting", color: "#C4A84D" },
+      { label: "Person", color: "#7a8493" },
     ];
     for (const [id, color] of companyColorMap.entries()) {
       const node = allNodes.find((n) => n.id === id);
@@ -538,7 +539,7 @@
       {error}
       {#if error?.includes("No recordings folder")}
         <br />
-        <a href="#settings" style="color: #A8A078; text-decoration: underline; font-weight: 600; margin-top: 8px; display: inline-block;">
+        <a href="#settings" style="color: var(--gold); text-decoration: underline; font-weight: 600; margin-top: 8px; display: inline-block;">
           Configure in Settings
         </a>
       {/if}
@@ -576,7 +577,7 @@
             markerHeight="6"
             orient="auto"
           >
-            <polygon points="0 0, 10 3.5, 0 7" fill="#464440" />
+            <polygon points="0 0, 10 3.5, 0 7" fill="#363d47" />
           </marker>
           <marker
             id="arrowhead-active"
@@ -587,7 +588,7 @@
             markerHeight="6"
             orient="auto"
           >
-            <polygon points="0 0, 10 3.5, 0 7" fill="#787470" />
+            <polygon points="0 0, 10 3.5, 0 7" fill="#4a5260" />
           </marker>
         {/if}
       </defs>
@@ -602,7 +603,7 @@
             y1={(link.source as SimNode).y ?? 0}
             x2={(link.target as SimNode).x ?? 0}
             y2={(link.target as SimNode).y ?? 0}
-            stroke={isLinkActive(link) ? "#787470" : "#464440"}
+            stroke={isLinkActive(link) ? "#4a5260" : "#363d47"}
             stroke-width={isLinkActive(link) ? 1.5 : 1}
             marker-end={showArrows ? (isLinkActive(link) ? "url(#arrowhead-active)" : "url(#arrowhead)") : "none"}
           />
@@ -635,7 +636,7 @@
                 x={node.x ?? 0}
                 y={(node.y ?? 0) + getRadius(node.node_type) + 12}
                 text-anchor="middle"
-                fill="#78756E"
+                fill="#7a8493"
                 font-family="'DM Sans', sans-serif"
                 font-size="10"
               >
@@ -682,15 +683,15 @@
     <!-- Legend -->
     <div class="graph-legend">
       <div class="graph-legend-item">
-        <span class="graph-legend-dot" style="background: #A8A078;"></span>
+        <span class="graph-legend-dot" style="background: var(--gold);"></span>
         Meetings
       </div>
       <div class="graph-legend-item">
-        <span class="graph-legend-dot" style="background: #78756E;"></span>
+        <span class="graph-legend-dot" style="background: var(--text-muted);"></span>
         People
       </div>
       <div class="graph-legend-item">
-        <span class="graph-legend-dot" style="background: #B4A882;"></span>
+        <span class="graph-legend-dot" style="background: var(--gold-muted);"></span>
         Companies
       </div>
     </div>
@@ -701,7 +702,7 @@
   .graph-container {
     width: 100%;
     height: calc(100vh - 48px);
-    background: #1D1D1B;
+    background: var(--bg);
     overflow: hidden;
     position: relative;
   }
@@ -713,11 +714,11 @@
     height: 100%;
     font-family: 'DM Sans', sans-serif;
     font-size: 15px;
-    color: #585650;
+    color: var(--text-faint);
   }
 
   .graph-error {
-    color: #D06850;
+    color: var(--red);
   }
 
   .graph-svg {
@@ -764,7 +765,7 @@
     gap: 16px;
     font-family: 'DM Sans', sans-serif;
     font-size: 12.5px;
-    color: #585650;
+    color: var(--text-faint);
   }
 
   .graph-legend-item {

--- a/src/routes/GraphView.svelte
+++ b/src/routes/GraphView.svelte
@@ -13,6 +13,7 @@
   import { graphDataVersion } from "../lib/stores/meetings";
   import { get } from "svelte/store";
   import { getGraphData, type GraphNode, type GraphEdge } from "../lib/tauri";
+  import { COMPANY_COLORS } from "../lib/theme";
   import { USE_DUMMY_DATA, DUMMY_GRAPH_DATA } from "../lib/dummy-data";
   import GraphControls from "../lib/components/GraphControls.svelte";
   import GraphSidebar from "../lib/components/GraphSidebar.svelte";
@@ -26,17 +27,6 @@
   interface SimLink extends SimulationLinkDatum<SimNode> {
     edge_type: string;
   }
-
-  // ── Company color palette (configurable) ──
-  const COMPANY_PALETTE = [
-    "#5e9e96",
-    "#8e6e9e",
-    "#9e826e",
-    "#6e829e",
-    "#9e6e7e",
-    "#7e9e6e",
-    "#9e9e6e",
-  ];
 
   let svgEl: SVGSVGElement | undefined = $state(undefined);
   let width = $state(900);
@@ -88,12 +78,12 @@
   };
 
   function getColor(node: SimNode): string {
-    if (node.node_type === "meeting") return "#C4A84D";
-    if (node.node_type === "person") return "#7a8493";
+    if (node.node_type === "meeting") return "var(--gold)";
+    if (node.node_type === "person") return "var(--text-muted)";
     if (node.node_type === "company") {
-      return companyColorMap.get(node.id) ?? "#b09840";
+      return companyColorMap.get(node.id) ?? "var(--gold-muted)";
     }
-    return "#7a8493";
+    return "var(--text-muted)";
   }
 
   function getRadius(nodeType: string): number {
@@ -104,7 +94,7 @@
     let idx = 0;
     for (const n of nodeList) {
       if (n.node_type === "company" && !companyColorMap.has(n.id)) {
-        companyColorMap.set(n.id, COMPANY_PALETTE[idx % COMPANY_PALETTE.length]);
+        companyColorMap.set(n.id, COMPANY_COLORS[idx % COMPANY_COLORS.length]);
         idx++;
       }
     }
@@ -113,8 +103,8 @@
   // Build groups list for controls panel
   let controlGroups = $derived.by(() => {
     const groups = [
-      { label: "Meeting", color: "#C4A84D" },
-      { label: "Person", color: "#7a8493" },
+      { label: "Meeting", color: "var(--gold)" },
+      { label: "Person", color: "var(--text-muted)" },
     ];
     for (const [id, color] of companyColorMap.entries()) {
       const node = allNodes.find((n) => n.id === id);
@@ -577,7 +567,7 @@
             markerHeight="6"
             orient="auto"
           >
-            <polygon points="0 0, 10 3.5, 0 7" fill="#363d47" />
+            <polygon points="0 0, 10 3.5, 0 7" style="fill: var(--border)" />
           </marker>
           <marker
             id="arrowhead-active"
@@ -588,7 +578,7 @@
             markerHeight="6"
             orient="auto"
           >
-            <polygon points="0 0, 10 3.5, 0 7" fill="#4a5260" />
+            <polygon points="0 0, 10 3.5, 0 7" style="fill: var(--text-faint)" />
           </marker>
         {/if}
       </defs>
@@ -603,7 +593,7 @@
             y1={(link.source as SimNode).y ?? 0}
             x2={(link.target as SimNode).x ?? 0}
             y2={(link.target as SimNode).y ?? 0}
-            stroke={isLinkActive(link) ? "#4a5260" : "#363d47"}
+            style="stroke: {isLinkActive(link) ? 'var(--text-faint)' : 'var(--border)'}"
             stroke-width={isLinkActive(link) ? 1.5 : 1}
             marker-end={showArrows ? (isLinkActive(link) ? "url(#arrowhead-active)" : "url(#arrowhead)") : "none"}
           />
@@ -636,7 +626,7 @@
                 x={node.x ?? 0}
                 y={(node.y ?? 0) + getRadius(node.node_type) + 12}
                 text-anchor="middle"
-                fill="#7a8493"
+                style="fill: var(--text-muted)"
                 font-family="'DM Sans', sans-serif"
                 font-size="10"
               >

--- a/src/routes/MeetingDetail.svelte
+++ b/src/routes/MeetingDetail.svelte
@@ -11,6 +11,7 @@
   import MeetingTranscript from "../lib/components/MeetingTranscript.svelte";
   import ScreenshotGallery from "../lib/components/ScreenshotGallery.svelte";
   import PipelineDots from "../lib/components/PipelineDots.svelte";
+  import SpeakerReview from "../lib/components/SpeakerReview.svelte";
 
   interface Props {
     meetingId: string;
@@ -77,6 +78,21 @@
   );
 
   let screenshotCount = $derived(detail?.screenshots.length ?? 0);
+
+  let needsSpeakerReview = $derived(
+    detail?.summary.pipeline_status.analyze?.waiting === "speaker_review"
+  );
+
+  let speakerLabels = $derived.by(() => {
+    if (!detail?.transcript) return {};
+    const counts: Record<string, number> = {};
+    for (const u of detail.transcript) {
+      if (u.speaker.startsWith("SPEAKER_")) {
+        counts[u.speaker] = (counts[u.speaker] ?? 0) + 1;
+      }
+    }
+    return counts;
+  });
 </script>
 
 <div class="flex flex-col min-h-screen" style="background: var(--bg);">
@@ -195,6 +211,14 @@
         {#if activeTab === "notes"}
           <MeetingNotes content={detail.note_content} />
         {:else if activeTab === "transcript"}
+          {#if needsSpeakerReview && detail.summary.recording_path && Object.keys(speakerLabels).length > 0}
+            <SpeakerReview
+              speakerLabels={speakerLabels}
+              calendarParticipants={detail.summary.participants}
+              recordingPath={detail.summary.recording_path}
+              onResumed={loadDetail}
+            />
+          {/if}
           <MeetingTranscript
             utterances={detail.transcript}
             onSeek={handleSeek}

--- a/src/routes/MeetingDetail.svelte
+++ b/src/routes/MeetingDetail.svelte
@@ -79,11 +79,11 @@
   let screenshotCount = $derived(detail?.screenshots.length ?? 0);
 </script>
 
-<div class="flex flex-col min-h-screen" style="background: #1D1D1B;">
+<div class="flex flex-col min-h-screen" style="background: var(--bg);">
   {#if loading}
     <div
       class="flex items-center justify-center h-screen"
-      style="font-family: 'DM Sans', sans-serif; color: #585650;"
+      style="font-family: 'DM Sans', sans-serif; color: var(--text-faint);"
     >
       <span class="spinner"></span>
     </div>
@@ -94,7 +94,7 @@
         style="
           font-family: 'DM Sans', sans-serif;
           font-size: 14px;
-          color: #A8A078;
+          color: var(--gold);
           text-decoration: none;
         "
       >&larr; Back</a>
@@ -102,7 +102,7 @@
         class="mt-4 p-3 rounded-lg"
         style="
           background: rgba(200,80,60,0.10);
-          color: #D06850;
+          color: var(--red);
           font-family: 'DM Sans', sans-serif;
           font-size: 14.5px;
         "
@@ -130,7 +130,7 @@
       <div
         class="flex gap-0"
         style="
-          border-bottom: 1px solid #262624;
+          border-bottom: 1px solid var(--border);
           font-family: 'DM Sans', sans-serif;
           font-size: 14.5px;
         "
@@ -145,8 +145,8 @@
             font-family: 'DM Sans', sans-serif;
             font-size: 14.5px;
             font-weight: {activeTab === 'notes' ? '600' : '400'};
-            color: {activeTab === 'notes' ? '#A8A078' : '#585650'};
-            border-bottom: 2px solid {activeTab === 'notes' ? '#A8A078' : 'transparent'};
+            color: {activeTab === 'notes' ? 'var(--gold)' : 'var(--text-faint)'};
+            border-bottom: 2px solid {activeTab === 'notes' ? 'var(--gold)' : 'transparent'};
             margin-bottom: -1px;
           "
         >
@@ -162,8 +162,8 @@
             font-family: 'DM Sans', sans-serif;
             font-size: 14.5px;
             font-weight: {activeTab === 'transcript' ? '600' : '400'};
-            color: {activeTab === 'transcript' ? '#A8A078' : '#585650'};
-            border-bottom: 2px solid {activeTab === 'transcript' ? '#A8A078' : 'transparent'};
+            color: {activeTab === 'transcript' ? 'var(--gold)' : 'var(--text-faint)'};
+            border-bottom: 2px solid {activeTab === 'transcript' ? 'var(--gold)' : 'transparent'};
             margin-bottom: -1px;
           "
         >
@@ -180,8 +180,8 @@
               font-family: 'DM Sans', sans-serif;
               font-size: 14.5px;
               font-weight: {activeTab === 'screenshots' ? '600' : '400'};
-              color: {activeTab === 'screenshots' ? '#A8A078' : '#585650'};
-              border-bottom: 2px solid {activeTab === 'screenshots' ? '#A8A078' : 'transparent'};
+              color: {activeTab === 'screenshots' ? 'var(--gold)' : 'var(--text-faint)'};
+              border-bottom: 2px solid {activeTab === 'screenshots' ? 'var(--gold)' : 'transparent'};
               margin-bottom: -1px;
             "
           >
@@ -212,8 +212,8 @@
     display: inline-block;
     width: 24px;
     height: 24px;
-    border: 2px solid #464440;
-    border-top-color: #A8A078;
+    border: 2px solid var(--border);
+    border-top-color: var(--gold);
     border-radius: 50%;
     animation: spin 0.8s linear infinite;
   }

--- a/src/routes/Settings.svelte
+++ b/src/routes/Settings.svelte
@@ -36,11 +36,11 @@
   let activeProvider = $derived(providers.find((p) => p.provider === activeModal));
 </script>
 
-<div style="height:100%;overflow-y:auto;background:#1D1D1B;">
+<div style="height:100%;overflow-y:auto;background:var(--bg);">
 <div style="max-width:700px;margin:0 auto;padding:24px 28px 48px;">
   <div style="display:flex;flex-direction:column;gap:28px;">
     <section>
-      <h2 style="font-family:'Source Serif 4',serif;font-size:18px;font-weight:600;color:#D8D5CE;margin-bottom:12px;">
+      <h2 style="font-family:'Source Serif 4',serif;font-size:18px;font-weight:600;color:var(--text);margin-bottom:12px;">
         Platform Connections
       </h2>
       <div style="display:flex;flex-direction:column;gap:4px;">
@@ -60,7 +60,7 @@
 
     <SettingsSection title="Recording">
       <RecordingSettings />
-      <div style="border-top:1px solid #262624;padding-top:12px;">
+      <div style="border-top:1px solid var(--border);padding-top:12px;">
         <RecordingBehaviorSettings />
       </div>
     </SettingsSection>

--- a/static/icon-source.svg
+++ b/static/icon-source.svg
@@ -1,11 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
   <!-- Warm Geometric v3: No background, fills the canvas -->
   <!-- Outer ring — thick stroke, centered -->
-  <circle cx="256" cy="220" r="175" fill="none" stroke="#A8A078" stroke-width="36"/>
+  <circle cx="256" cy="220" r="175" fill="none" stroke="#C4A84D" stroke-width="36"/>
   <!-- Inner filled circle — record dot -->
-  <circle cx="256" cy="220" r="65" fill="#A8A078"/>
+  <circle cx="256" cy="220" r="65" fill="#C4A84D"/>
   <!-- Three participant dots — large -->
-  <circle cx="148" cy="460" r="32" fill="#78756E"/>
-  <circle cx="256" cy="460" r="32" fill="#A8A078"/>
-  <circle cx="364" cy="460" r="32" fill="#78756E"/>
+  <circle cx="148" cy="460" r="32" fill="#7a8493"/>
+  <circle cx="256" cy="460" r="32" fill="#C4A84D"/>
+  <circle cx="364" cy="460" r="32" fill="#7a8493"/>
 </svg>

--- a/tests/test_pipeline_pause.py
+++ b/tests/test_pipeline_pause.py
@@ -114,6 +114,12 @@ class TestPipelinePause:
         status = json.loads(status_path.read_text())
         assert status["analyze"]["waiting"] == "speaker_review"
 
+        # Status should also be copied to recordings dir (<recording>.status.json)
+        recordings_status = config.recordings_path / "meeting.status.json"
+        assert recordings_status.exists(), "status.json was not copied to recordings dir"
+        rec_status = json.loads(recordings_status.read_text())
+        assert rec_status["analyze"]["waiting"] == "speaker_review"
+
     @patch("recap.pipeline.analyze")
     @patch("recap.pipeline.extract_frames")
     @patch("recap.pipeline.transcribe")

--- a/tests/test_pipeline_pause.py
+++ b/tests/test_pipeline_pause.py
@@ -115,7 +115,8 @@ class TestPipelinePause:
         assert status["analyze"]["waiting"] == "speaker_review"
 
         # Status should also be copied to recordings dir (<recording>.status.json)
-        recordings_status = config.recordings_path / "meeting.status.json"
+        # The pipeline slugifies the title, so the filename is date-slug.status.json
+        recordings_status = config.recordings_path / "2026-03-17-quick-sync.status.json"
         assert recordings_status.exists(), "status.json was not copied to recordings dir"
         rec_status = json.loads(recordings_status.read_text())
         assert rec_status["analyze"]["waiting"] == "speaker_review"

--- a/tests/test_pipeline_pause.py
+++ b/tests/test_pipeline_pause.py
@@ -1,0 +1,138 @@
+"""Tests for pipeline pause when no participants are available."""
+import json
+import pathlib
+from datetime import date
+from unittest.mock import patch
+
+import pytest
+
+from recap.config import RecapConfig, WhisperXConfig, TodoistConfig, ClaudeConfig
+from recap.models import TranscriptResult, Utterance
+from recap.pipeline import run_pipeline
+
+
+@pytest.fixture
+def config(tmp_path) -> RecapConfig:
+    vault = tmp_path / "vault"
+    (vault / "Work" / "Meetings").mkdir(parents=True)
+    (vault / "Work" / "People").mkdir(parents=True)
+    (vault / "Work" / "Companies").mkdir(parents=True)
+    recordings = tmp_path / "recordings"
+    recordings.mkdir()
+    frames = tmp_path / "frames"
+    frames.mkdir()
+    (tmp_path / "logs").mkdir()
+
+    return RecapConfig(
+        vault_path=vault,
+        recordings_path=recordings,
+        frames_path=frames,
+        user_name="Tim",
+        whisperx=WhisperXConfig(),
+        huggingface_token="hf_fake",
+        todoist=TodoistConfig(api_token="test", default_project="Recap", project_map={}),
+        claude=ClaudeConfig(command="claude"),
+    )
+
+
+@pytest.fixture
+def metadata_no_participants(tmp_path) -> pathlib.Path:
+    meta = {
+        "title": "Quick Sync",
+        "date": "2026-03-17",
+        "participants": [],
+        "platform": "zoom",
+    }
+    path = tmp_path / "meeting.json"
+    path.write_text(json.dumps(meta))
+    return path
+
+
+@pytest.fixture
+def audio_file(tmp_path) -> pathlib.Path:
+    path = tmp_path / "meeting.mp4"
+    path.write_bytes(b"fake audio content")
+    return path
+
+
+@pytest.fixture
+def mock_transcript() -> TranscriptResult:
+    return TranscriptResult(
+        utterances=[
+            Utterance(speaker="SPEAKER_00", start=0.0, end=3.0, text="Hello."),
+        ],
+        raw_text="Hello.",
+        language="en",
+    )
+
+
+class TestPipelinePause:
+    @patch("recap.pipeline.extract_frames")
+    @patch("recap.pipeline.transcribe")
+    @patch("recap.pipeline._get_audio_duration")
+    def test_pauses_when_no_participants(
+        self,
+        mock_duration,
+        mock_transcribe,
+        mock_frames,
+        config,
+        metadata_no_participants,
+        audio_file,
+        mock_transcript,
+    ):
+        mock_duration.return_value = 600.0
+        mock_transcribe.return_value = mock_transcript
+        mock_frames.return_value = []
+
+        result = run_pipeline(audio_file, metadata_no_participants, config)
+
+        assert result["paused"] is True
+        assert result["waiting_at"] == "analyze"
+
+    @patch("recap.pipeline.extract_frames")
+    @patch("recap.pipeline.transcribe")
+    @patch("recap.pipeline._get_audio_duration")
+    def test_pause_writes_status_json(
+        self,
+        mock_duration,
+        mock_transcribe,
+        mock_frames,
+        config,
+        metadata_no_participants,
+        audio_file,
+        mock_transcript,
+    ):
+        mock_duration.return_value = 600.0
+        mock_transcribe.return_value = mock_transcript
+        mock_frames.return_value = []
+
+        run_pipeline(audio_file, metadata_no_participants, config)
+
+        # Status should be written to working dir
+        status_path = audio_file.parent / "status.json"
+        assert status_path.exists()
+        status = json.loads(status_path.read_text())
+        assert status["analyze"]["waiting"] == "speaker_review"
+
+    @patch("recap.pipeline.analyze")
+    @patch("recap.pipeline.extract_frames")
+    @patch("recap.pipeline.transcribe")
+    @patch("recap.pipeline._get_audio_duration")
+    def test_pause_does_not_call_analyze(
+        self,
+        mock_duration,
+        mock_transcribe,
+        mock_frames,
+        mock_analyze,
+        config,
+        metadata_no_participants,
+        audio_file,
+        mock_transcript,
+    ):
+        mock_duration.return_value = 600.0
+        mock_transcribe.return_value = mock_transcript
+        mock_frames.return_value = []
+
+        run_pipeline(audio_file, metadata_no_participants, config)
+
+        mock_analyze.assert_not_called()

--- a/tests/test_pipeline_waiting.py
+++ b/tests/test_pipeline_waiting.py
@@ -1,0 +1,47 @@
+"""Tests for the pipeline waiting field."""
+import json
+import pathlib
+
+from recap.pipeline import (
+    PIPELINE_STAGES,
+    _load_status,
+    _mark_stage,
+    _mark_waiting,
+    _save_status,
+)
+
+
+def test_default_status_includes_waiting(tmp_path: pathlib.Path) -> None:
+    """Default status dict should have waiting: None for every stage."""
+    status = _load_status(tmp_path)
+    for stage in PIPELINE_STAGES:
+        assert "waiting" in status[stage], f"missing 'waiting' key in stage {stage}"
+        assert status[stage]["waiting"] is None
+
+
+def test_mark_waiting_sets_reason(tmp_path: pathlib.Path) -> None:
+    """_mark_waiting should set the waiting field to the given reason."""
+    status = _load_status(tmp_path)
+    _mark_waiting(status, "diarize", "Awaiting speaker review")
+    assert status["diarize"]["waiting"] == "Awaiting speaker review"
+
+
+def test_mark_stage_clears_waiting(tmp_path: pathlib.Path) -> None:
+    """_mark_stage should reset waiting to None."""
+    status = _load_status(tmp_path)
+    _mark_waiting(status, "diarize", "Awaiting speaker review")
+    _mark_stage(status, "diarize", True)
+    assert status["diarize"]["waiting"] is None
+
+
+def test_waiting_persists_to_json(tmp_path: pathlib.Path) -> None:
+    """Waiting field should be written to and read from status.json."""
+    status = _load_status(tmp_path)
+    _mark_waiting(status, "analyze", "Awaiting speaker review")
+    _save_status(tmp_path, status)
+
+    raw = json.loads((tmp_path / "status.json").read_text())
+    assert raw["analyze"]["waiting"] == "Awaiting speaker review"
+
+    reloaded = _load_status(tmp_path)
+    assert reloaded["analyze"]["waiting"] == "Awaiting speaker review"

--- a/tests/test_speaker_labels.py
+++ b/tests/test_speaker_labels.py
@@ -1,0 +1,66 @@
+"""Tests for speaker label correction logic."""
+import json
+import pathlib
+
+import pytest
+
+from recap.models import TranscriptResult, Utterance
+from recap.pipeline import _apply_speaker_labels
+
+
+@pytest.fixture
+def transcript() -> TranscriptResult:
+    return TranscriptResult(
+        utterances=[
+            Utterance(speaker="SPEAKER_00", start=0.0, end=3.0, text="Hello everyone."),
+            Utterance(speaker="SPEAKER_01", start=3.0, end=6.0, text="Hi there."),
+            Utterance(speaker="SPEAKER_00", start=6.0, end=9.0, text="Let's begin."),
+            Utterance(speaker="SPEAKER_02", start=9.0, end=12.0, text="Sounds good."),
+        ],
+        raw_text="Hello everyone. Hi there. Let's begin. Sounds good.",
+        language="en",
+    )
+
+
+class TestApplySpeakerLabels:
+    def test_applies_corrections(self, transcript, tmp_path):
+        labels_path = tmp_path / "speaker_labels.json"
+        labels_path.write_text(json.dumps({
+            "SPEAKER_00": "Tim",
+            "SPEAKER_01": "Jane Smith",
+        }))
+
+        result = _apply_speaker_labels(transcript, labels_path)
+
+        assert result.utterances[0].speaker == "Tim"
+        assert result.utterances[1].speaker == "Jane Smith"
+        assert result.utterances[2].speaker == "Tim"
+        # SPEAKER_02 not in labels, should remain unchanged
+        assert result.utterances[3].speaker == "SPEAKER_02"
+
+    def test_no_labels_file_returns_transcript_unchanged(self, transcript, tmp_path):
+        labels_path = tmp_path / "speaker_labels.json"
+        # File does not exist
+
+        result = _apply_speaker_labels(transcript, labels_path)
+
+        assert result.utterances[0].speaker == "SPEAKER_00"
+        assert result.utterances[1].speaker == "SPEAKER_01"
+
+    def test_empty_labels_returns_transcript_unchanged(self, transcript, tmp_path):
+        labels_path = tmp_path / "speaker_labels.json"
+        labels_path.write_text(json.dumps({}))
+
+        result = _apply_speaker_labels(transcript, labels_path)
+
+        assert result.utterances[0].speaker == "SPEAKER_00"
+        assert result.utterances[1].speaker == "SPEAKER_01"
+
+    def test_returns_same_object(self, transcript, tmp_path):
+        """_apply_speaker_labels mutates in place and returns the same object."""
+        labels_path = tmp_path / "speaker_labels.json"
+        labels_path.write_text(json.dumps({"SPEAKER_00": "Tim"}))
+
+        result = _apply_speaker_labels(transcript, labels_path)
+
+        assert result is transcript


### PR DESCRIPTION
## Summary
- Migrate from Warm Ink to Recap Dark color scheme (GitHub-inspired, CSS custom properties across ~30 files)
- Add Zoho Calendar integration with local cache, event-recording matching, and Calendar view
- Implement speaker correction with pipeline pausing (`waiting` field on PipelineStageStatus), inline review UI with searchable participant dropdown
- Build pre-meeting briefing notifications via Claude CLI with structured JSON output and caching
- Add Ctrl+Scroll/+/-/0 zoom controls with persistence
- Add pre-meeting notification trigger with configurable lead time

## New Files
- `src-tauri/src/calendar.rs` — Zoho Calendar API, cache, event-recording matching
- `src-tauri/src/briefing.rs` — Claude CLI briefing generation with caching
- `src-tauri/src/notifications.rs` — Pre-meeting notification trigger
- `src/routes/Calendar.svelte` — Calendar view with upcoming/past events
- `src/lib/components/SpeakerReview.svelte` — Inline speaker label correction
- `src/lib/components/BriefingPanel.svelte` — Pre-meeting briefing display
- `src/lib/theme.ts` — Shared color palettes
- `prompts/meeting_briefing.md` — Claude CLI briefing prompt template

## Test plan
- [ ] Verify theme renders correctly across all views (Dashboard, Graph, Meeting Detail, Settings, Calendar)
- [ ] Verify Ctrl+/-/0 and Ctrl+Scroll zoom works and persists
- [ ] Verify pipeline dots show pulsing gold state for `waiting` status
- [ ] Verify SpeakerReview component renders with searchable dropdown
- [ ] Verify Calendar view shows empty state when Zoho not connected
- [ ] Verify BriefingPanel loading/error/success states
- [ ] Verify notification settings toggle and lead time selector
- [ ] All 88 Python tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)